### PR TITLE
Fix observability workflow Alertmanager rendering

### DIFF
--- a/.github/workflows/observability-production.yml
+++ b/.github/workflows/observability-production.yml
@@ -130,56 +130,52 @@ jobs:
           alertmanager_receivers=$'receivers:\n  - name: "null"\n'
           if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
             alertmanager_route_entries+=$'    - receiver: "slack"\n      continue: true\n'
-            alertmanager_receivers+=$'\n'
-            alertmanager_receivers+="$(cat <<ALERTSLACK
-              - name: "slack"
-                slack_configs:
-                  - api_url: "${SLACK_WEBHOOK_URL}"
-                    username: "Smart Tutor Alerts"
-                    icon_emoji: ":rotating_light:"
-                    send_resolved: true
-                    color: '{{ if eq .Status "resolved" }}good{{ else if eq .CommonLabels.severity "critical" }}danger{{ else }}warning{{ end }}'
-                    title: '[{{ .CommonLabels.severity | toUpper }}] {{ .CommonLabels.alertname }}'
-                    pretext: '{{ if eq .Status "resolved" }}Resolved{{ else }}Firing{{ end }} alert for Smart AI Tutor production'
-                    text: '{{ range .Alerts }}- *{{ .Annotations.summary }}*{{ if .Annotations.description }}\n{{ .Annotations.description }}{{ end }}{{ "\n" }}{{ end }}'
-                    fields:
-                      - title: "Environment"
-                        value: '{{ .CommonLabels.environment }}'
-                        short: true
-                      - title: "Component"
-                        value: '{{ .CommonLabels.component }}'
-                        short: true
-                      - title: "Status"
-                        value: '{{ .Status }}'
-                        short: true
-                      - title: "Alert Count"
-                        value: '{{ len .Alerts }}'
-                        short: true
-                    footer: 'Alertmanager via Production Observability'
-                    mrkdwn_in:
-                      - pretext
-                      - text
-          ALERTSLACK
-          )"
+            alertmanager_receivers+="$(
+              printf '%s\n' '  - name: "slack"'
+              printf '%s\n' '    slack_configs:'
+              printf '%s\n' "      - api_url: \"${SLACK_WEBHOOK_URL}\""
+              printf '%s\n' '        username: "Smart Tutor Alerts"'
+              printf '%s\n' '        icon_emoji: ":rotating_light:"'
+              printf '%s\n' '        send_resolved: true'
+              printf '%s\n' "        color: '{{ if eq .Status \"resolved\" }}good{{ else if eq .CommonLabels.severity \"critical\" }}danger{{ else }}warning{{ end }}'"
+              printf '%s\n' "        title: '[{{ .CommonLabels.severity | toUpper }}] {{ .CommonLabels.alertname }}'"
+              printf '%s\n' "        pretext: '{{ if eq .Status \"resolved\" }}Resolved{{ else }}Firing{{ end }} alert for Smart AI Tutor production'"
+              printf '%s\n' "        text: '{{ range .Alerts }}- *{{ .Annotations.summary }}*{{ if .Annotations.description }}\\n{{ .Annotations.description }}{{ end }}{{ \"\\n\" }}{{ end }}'"
+              printf '%s\n' '        fields:'
+              printf '%s\n' '          - title: "Environment"'
+              printf '%s\n' "            value: '{{ .CommonLabels.environment }}'"
+              printf '%s\n' '            short: true'
+              printf '%s\n' '          - title: "Component"'
+              printf '%s\n' "            value: '{{ .CommonLabels.component }}'"
+              printf '%s\n' '            short: true'
+              printf '%s\n' '          - title: "Status"'
+              printf '%s\n' "            value: '{{ .Status }}'"
+              printf '%s\n' '            short: true'
+              printf '%s\n' '          - title: "Alert Count"'
+              printf '%s\n' "            value: '{{ len .Alerts }}'"
+              printf '%s\n' '            short: true'
+              printf '%s\n' "        footer: 'Alertmanager via Production Observability'"
+              printf '%s\n' '        mrkdwn_in:'
+              printf '%s\n' '          - pretext'
+              printf '%s\n' '          - text'
+            )"
             alertmanager_receivers+=$'\n'
           fi
 
           if [ -n "${ALERTS_EMAIL_TO:-${EMAIL_FROM:-}}" ] && [ -n "${SMTP_SERVER:-}" ] && [ -n "${SMTP_USERNAME:-}" ] && [ -n "${SMTP_PASSWORD:-}" ]; then
             alert_email_to="${ALERTS_EMAIL_TO:-${EMAIL_FROM}}"
             alertmanager_route_entries+=$'    - receiver: "email"\n      continue: true\n'
-            alertmanager_receivers+=$'\n'
-            alertmanager_receivers+="$(cat <<ALERTEMAIL
-              - name: "email"
-                email_configs:
-                  - to: "${alert_email_to}"
-                    from: "${EMAIL_FROM:-${SMTP_USERNAME}}"
-                    smarthost: "${SMTP_SERVER}:${SMTP_PORT:-587}"
-                    auth_username: "${SMTP_USERNAME}"
-                    auth_password: "${SMTP_PASSWORD}"
-                    require_tls: true
-                    send_resolved: true
-          ALERTEMAIL
-          )"
+            alertmanager_receivers+="$(
+              printf '%s\n' '  - name: "email"'
+              printf '%s\n' '    email_configs:'
+              printf '%s\n' "      - to: \"${alert_email_to}\""
+              printf '%s\n' "        from: \"${EMAIL_FROM:-${SMTP_USERNAME}}\""
+              printf '%s\n' "        smarthost: \"${SMTP_SERVER}:${SMTP_PORT:-587}\""
+              printf '%s\n' "        auth_username: \"${SMTP_USERNAME}\""
+              printf '%s\n' "        auth_password: \"${SMTP_PASSWORD}\""
+              printf '%s\n' '        require_tls: true'
+              printf '%s\n' '        send_resolved: true'
+            )"
             alertmanager_receivers+=$'\n'
           fi
 
@@ -203,19 +199,21 @@ jobs:
           REDIS_PASSWORD=${REDIS_PASSWORD}
           ENVFILE
 
-          cat > monitoring/alertmanager/alertmanager.yml <<ALERTMANAGER
-          global:
-            resolve_timeout: 5m
-          route:
-            receiver: "null"
-            group_by: ["alertname", "component", "severity"]
-            group_wait: 30s
-            group_interval: 5m
-            repeat_interval: 4h
-          ${alertmanager_routes_block}
-
-          ${alertmanager_receivers}
-          ALERTMANAGER
+          {
+            printf '%s\n' 'global:'
+            printf '%s\n' '  resolve_timeout: 5m'
+            printf '%s\n' 'route:'
+            printf '%s\n' '  receiver: "null"'
+            printf '%s\n' '  group_by: ["alertname", "component", "severity"]'
+            printf '%s\n' '  group_wait: 30s'
+            printf '%s\n' '  group_interval: 5m'
+            printf '%s\n' '  repeat_interval: 4h'
+            if [ -n "${alertmanager_routes_block}" ]; then
+              printf '%s\n' "${alertmanager_routes_block}"
+            fi
+            printf '\n'
+            printf '%s\n' "${alertmanager_receivers}"
+          } > monitoring/alertmanager/alertmanager.yml
 
           docker network inspect smart-tutor_smart-tutor-network >/dev/null 2>&1 || \
             docker network create smart-tutor_smart-tutor-network


### PR DESCRIPTION
## Summary
- replace fragile shell heredoc assembly for Alertmanager receivers with deterministic printf-based rendering
- write the generated alertmanager.yml via printf to preserve valid YAML indentation on EC2
- keep the existing observability validation flow while fixing the Alertmanager startup failure

## Validation
- parsed .github/workflows/observability-production.yml as YAML locally
- extracted the bootstrap run script and passed bash -n
- rendered a sample alertmanager.yml locally and verified it parses as YAML
