### PR TITLE
Fix production workflow push path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,3 +192,8 @@ NEO4J_USER=neo4j
 # SECURITY: Change this! Generate a strong password (min 32 chars)
 NEO4J_PASSWORD=<generate-strong-password-here>
 NEO4J_DATABASE=neo4j
+# Optional: Neo4j Aura API credentials used to resume paused AuraDB Free instances.
+# Create these in Neo4j Aura Console -> Account Settings -> API Keys.
+NEO4J_AURA_INSTANCE_ID=
+NEO4J_AURA_CLIENT_ID=
+NEO4J_AURA_CLIENT_SECRET=

--- a/.github/workflows/compliance-production.yml
+++ b/.github/workflows/compliance-production.yml
@@ -20,6 +20,10 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       EC2_HOST: ${{ secrets.EC2_HOST }}
+      EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID || vars.EC2_INSTANCE_ID || '' }}
+      EC2_INSTANCE_NAME: ${{ vars.EC2_INSTANCE_NAME || '' }}
+      EC2_AUTO_START: ${{ vars.EC2_AUTO_START || 'true' }}
+      EC2_TEMPORARY_SSH_INGRESS: ${{ vars.EC2_TEMPORARY_SSH_INGRESS || 'true' }}
       EC2_USER: ${{ secrets.EC2_USER }}
       EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
       EC2_APP_DIR: ${{ vars.EC2_APP_DIR || '' }}
@@ -31,11 +35,14 @@ jobs:
         run: |
           set -euo pipefail
           missing=()
-          for name in EC2_HOST EC2_USER EC2_SSH_KEY; do
+          for name in EC2_USER EC2_SSH_KEY; do
             if [ -z "${!name:-}" ]; then
               missing+=("$name")
             fi
           done
+          if [ -z "${EC2_HOST:-}" ] && [ -z "${EC2_INSTANCE_ID:-}" ] && [ -z "${EC2_INSTANCE_NAME:-}" ]; then
+            missing+=("EC2_HOST or EC2_INSTANCE_ID/EC2_INSTANCE_NAME")
+          fi
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::Missing required production compliance configuration."
             for item in "${missing[@]}"; do
@@ -50,6 +57,9 @@ jobs:
       - name: Install AWS CLI
         if: ${{ env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != '' }}
         uses: unfor19/install-aws-cli-action@v1
+
+      - name: Resolve production EC2 target
+        run: scripts/ci/resolve_ec2_target.sh
 
       - name: Capture AWS compliance snapshot from runner
         if: ${{ env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != '' }}
@@ -75,11 +85,19 @@ jobs:
 
           capture_snapshot "aws-identity" "/tmp/compliance-report/aws-identity.json" "{}" \
             aws sts get-caller-identity
-          capture_snapshot "ec2-instance" "/tmp/compliance-report/ec2-instance.json" "[]" \
-            aws ec2 describe-instances \
-              --filters "Name=ip-address,Values=${EC2_HOST}" \
-              --query 'Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,InstanceType:InstanceType,LaunchTime:LaunchTime,PublicIpAddress:PublicIpAddress,IMDSv2:MetadataOptions.HttpTokens,RootVolumeEncrypted:BlockDeviceMappings[0].Ebs.Encrypted,SecurityGroups:SecurityGroups[*].GroupId}' \
-              --output json
+          if [ -n "${EC2_RESOLVED_INSTANCE_ID:-}" ]; then
+            capture_snapshot "ec2-instance" "/tmp/compliance-report/ec2-instance.json" "[]" \
+              aws ec2 describe-instances \
+                --instance-ids "${EC2_RESOLVED_INSTANCE_ID}" \
+                --query 'Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,InstanceType:InstanceType,LaunchTime:LaunchTime,PublicIpAddress:PublicIpAddress,IMDSv2:MetadataOptions.HttpTokens,RootVolumeEncrypted:BlockDeviceMappings[0].Ebs.Encrypted,SecurityGroups:SecurityGroups[*].GroupId}' \
+                --output json
+          else
+            capture_snapshot "ec2-instance" "/tmp/compliance-report/ec2-instance.json" "[]" \
+              aws ec2 describe-instances \
+                --filters "Name=ip-address,Values=${EC2_HOST}" \
+                --query 'Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,InstanceType:InstanceType,LaunchTime:LaunchTime,PublicIpAddress:PublicIpAddress,IMDSv2:MetadataOptions.HttpTokens,RootVolumeEncrypted:BlockDeviceMappings[0].Ebs.Encrypted,SecurityGroups:SecurityGroups[*].GroupId}' \
+                --output json
+          fi
 
       - name: Run remote EC2 compliance checks
         run: |
@@ -90,8 +108,14 @@ jobs:
           printf '%s\n' "${EC2_SSH_KEY}" > "${key_file}"
           chmod 600 "${key_file}"
           remote_app_dir="$(printf '%q' "${EC2_APP_DIR}")"
+          ssh_opts=(-o StrictHostKeyChecking=no -o LogLevel=ERROR -o BatchMode=yes -o ConnectTimeout=20 -o ConnectionAttempts=2 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes)
 
-          ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "EC2_APP_DIR=${remote_app_dir} bash -s" > /tmp/compliance-report/ec2-host-checks.txt <<'EOF'
+          if ! ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "printf 'ssh-ok\n'"; then
+            echo "::error::Unable to reach production EC2 over SSH. Verify the resolved host, instance state, and security group ingress for GitHub-hosted runners on port 22."
+            exit 1
+          fi
+
+          ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "EC2_APP_DIR=${remote_app_dir} bash -s" > /tmp/compliance-report/ec2-host-checks.txt <<'EOF'
           set -euo pipefail
 
           failures=0
@@ -162,7 +186,7 @@ jobs:
           if backend_health; then
             echo "[PASS] backend health endpoint responds"
           else
-            echo "[INFO] backend health endpoint is unavailable or degraded; readiness probe passed"
+            echo "[INFO] backend health endpoint is unavailable or degraded"
           fi
           check "shared logs directory exists" timed 10 sh -c "test -d \"${DATA_ROOT}/logs\""
           check "shared user data directory exists" timed 10 sh -c "test -d \"${DATA_ROOT}/user_data\""
@@ -180,7 +204,7 @@ jobs:
           timed 20 docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}' || true
           echo ""
           echo "=== Backend health status ==="
-          timed 20 backend_health_status || true
+          backend_health_status || true
 
           if [ "${failures}" -gt 0 ]; then
             exit 1
@@ -224,7 +248,7 @@ jobs:
               return 0
             fi
 
-            if ssh -o StrictHostKeyChecking=no -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "command -v aws >/dev/null 2>&1 && $*" > "${target}"; then
+            if ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -o BatchMode=yes -o ConnectTimeout=20 -o ConnectionAttempts=2 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "command -v aws >/dev/null 2>&1 && $*" > "${target}"; then
               rm -f "/tmp/compliance-report/aws-fallback-needed/${name}"
               echo "Captured ${name} from EC2 fallback."
             else
@@ -235,10 +259,19 @@ jobs:
 
           capture_remote_snapshot "aws-identity" "/tmp/compliance-report/aws-identity.json" "{}" \
             aws sts get-caller-identity
-          capture_remote_snapshot "ec2-instance" "/tmp/compliance-report/ec2-instance.json" "[]" \
-            aws ec2 describe-instances --filters "Name=ip-address,Values=${EC2_HOST}" --query "'Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,InstanceType:InstanceType,LaunchTime:LaunchTime,PublicIpAddress:PublicIpAddress,IMDSv2:MetadataOptions.HttpTokens,RootVolumeEncrypted:BlockDeviceMappings[0].Ebs.Encrypted,SecurityGroups:SecurityGroups[*].GroupId}'" --output json
+          if [ -n "${EC2_RESOLVED_INSTANCE_ID:-}" ]; then
+            capture_remote_snapshot "ec2-instance" "/tmp/compliance-report/ec2-instance.json" "[]" \
+              aws ec2 describe-instances --instance-ids "${EC2_RESOLVED_INSTANCE_ID}" --query "'Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,InstanceType:InstanceType,LaunchTime:LaunchTime,PublicIpAddress:PublicIpAddress,IMDSv2:MetadataOptions.HttpTokens,RootVolumeEncrypted:BlockDeviceMappings[0].Ebs.Encrypted,SecurityGroups:SecurityGroups[*].GroupId}'" --output json
+          else
+            capture_remote_snapshot "ec2-instance" "/tmp/compliance-report/ec2-instance.json" "[]" \
+              aws ec2 describe-instances --filters "Name=ip-address,Values=${EC2_HOST}" --query "'Reservations[*].Instances[*].{InstanceId:InstanceId,State:State.Name,InstanceType:InstanceType,LaunchTime:LaunchTime,PublicIpAddress:PublicIpAddress,IMDSv2:MetadataOptions.HttpTokens,RootVolumeEncrypted:BlockDeviceMappings[0].Ebs.Encrypted,SecurityGroups:SecurityGroups[*].GroupId}'" --output json
+          fi
 
           rm -f "${key_file}"
+
+      - name: Revoke temporary SSH ingress
+        if: always()
+        run: scripts/ci/revoke_ec2_ssh_ingress.sh
 
       - name: Upload compliance artifacts
         if: always()
@@ -308,7 +341,6 @@ jobs:
         with:
           name: production-compliance-report
           path: /tmp/compliance-report
-          if-no-files-found: ignore
 
       - name: Resolve status and summary
         id: vars
@@ -318,9 +350,9 @@ jobs:
           fail_count="0"
           info_count="0"
           if [ -f /tmp/compliance-report/ec2-host-checks.txt ]; then
-            pass_count="$(grep -c '^\\[PASS\\]' /tmp/compliance-report/ec2-host-checks.txt || true)"
-            fail_count="$(grep -c '^\\[FAIL\\]' /tmp/compliance-report/ec2-host-checks.txt || true)"
-            info_count="$(grep -c '^\\[INFO\\]' /tmp/compliance-report/ec2-host-checks.txt || true)"
+            pass_count="$(grep -c '^\[PASS\]' /tmp/compliance-report/ec2-host-checks.txt || true)"
+            fail_count="$(grep -c '^\[FAIL\]' /tmp/compliance-report/ec2-host-checks.txt || true)"
+            info_count="$(grep -c '^\[INFO\]' /tmp/compliance-report/ec2-host-checks.txt || true)"
           fi
           echo "overall=${overall}" >> "$GITHUB_OUTPUT"
           echo "pass_count=${pass_count}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/neo4j-aura-resume.yml
+++ b/.github/workflows/neo4j-aura-resume.yml
@@ -1,0 +1,69 @@
+name: Neo4j Aura Resume Guard
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: neo4j-aura-resume
+  cancel-in-progress: false
+
+jobs:
+  resume-aura:
+    name: Resume Neo4j Aura If Paused
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    env:
+      NEO4J_AURA_INSTANCE_ID: ${{ secrets.NEO4J_AURA_INSTANCE_ID || vars.NEO4J_AURA_INSTANCE_ID || 'b0e9fb13' }}
+      NEO4J_AURA_CLIENT_ID: ${{ secrets.NEO4J_AURA_CLIENT_ID || secrets.NEO4J_AURA_API_CLIENT_ID }}
+      NEO4J_AURA_CLIENT_SECRET: ${{ secrets.NEO4J_AURA_CLIENT_SECRET || secrets.NEO4J_AURA_API_CLIENT_SECRET }}
+      NEO4J_AURA_POLL_TIMEOUT_SECONDS: ${{ vars.NEO4J_AURA_POLL_TIMEOUT_SECONDS || '420' }}
+      NEO4J_AURA_POLL_INTERVAL_SECONDS: ${{ vars.NEO4J_AURA_POLL_INTERVAL_SECONDS || '15' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resume paused Aura instance
+        id: resume
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          python3 scripts/resume_neo4j_aura.py
+
+      - name: Notify deployment analytics when Aura was resumed
+        if: ${{ steps.resume.outcome == 'success' && steps.resume.outputs.action == 'resumed' }}
+        uses: ./.github/actions/send-slack-notification
+        with:
+          channel: APP_DEV_ANALYTICS
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_APP_DEV_ANALYTICS }}
+          workflow_name: Neo4j Aura Resume Guard
+          status: success
+          verbiage: Aura Resume
+          message: |
+            :white_check_mark: *Neo4j Aura instance resumed*
+            The scheduled guard resumed the paused AuraDB instance and waited until it was running.
+          fields: >-
+            [{"title":"Instance","value":"${{ steps.resume.outputs.instance_name || steps.resume.outputs.instance_id }}","short":true},{"title":"Status","value":"${{ steps.resume.outputs.status }}","short":true}]
+
+      - name: Notify deployment analytics when Aura resume failed
+        if: ${{ steps.resume.outcome != 'success' }}
+        uses: ./.github/actions/send-slack-notification
+        with:
+          channel: APP_DEV_ANALYTICS
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_APP_DEV_ANALYTICS }}
+          workflow_name: Neo4j Aura Resume Guard
+          status: failure
+          verbiage: Aura Resume
+          message: |
+            :x: *Neo4j Aura resume guard FAILED*
+            The application may fail Neo4j-backed features until the AuraDB instance is running.
+          fields: >-
+            [{"title":"Instance","value":"${{ steps.resume.outputs.instance_id || env.NEO4J_AURA_INSTANCE_ID }}","short":true},{"title":"Last status","value":"${{ steps.resume.outputs.status || 'unknown' }}","short":true},{"title":"Action","value":"${{ steps.resume.outputs.action || 'failed' }}","short":true}]
+
+      - name: Fail workflow when resume guard failed
+        if: ${{ steps.resume.outcome != 'success' }}
+        run: exit 1

--- a/.github/workflows/observability-production.yml
+++ b/.github/workflows/observability-production.yml
@@ -18,10 +18,17 @@ jobs:
       contents: read
     env:
       EC2_HOST: ${{ secrets.EC2_HOST }}
+      EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID || vars.EC2_INSTANCE_ID || '' }}
+      EC2_INSTANCE_NAME: ${{ vars.EC2_INSTANCE_NAME || '' }}
+      EC2_AUTO_START: ${{ vars.EC2_AUTO_START || 'true' }}
+      EC2_TEMPORARY_SSH_INGRESS: ${{ vars.EC2_TEMPORARY_SSH_INGRESS || 'true' }}
       EC2_USER: ${{ secrets.EC2_USER }}
       EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
       GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
       OBSERVABILITY_DIR: ${{ vars.EC2_OBSERVABILITY_DIR || '/home/ubuntu/smart-tutor-observability' }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID || '' }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY || '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -30,11 +37,14 @@ jobs:
         run: |
           set -euo pipefail
           missing=()
-          for name in EC2_HOST EC2_USER EC2_SSH_KEY GRAFANA_ADMIN_PASSWORD; do
+          for name in EC2_USER EC2_SSH_KEY GRAFANA_ADMIN_PASSWORD; do
             if [ -z "${!name:-}" ]; then
               missing+=("$name")
             fi
           done
+          if [ -z "${EC2_HOST:-}" ] && [ -z "${EC2_INSTANCE_ID:-}" ] && [ -z "${EC2_INSTANCE_NAME:-}" ]; then
+            missing+=("EC2_HOST or EC2_INSTANCE_ID/EC2_INSTANCE_NAME")
+          fi
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::Missing required production observability configuration."
             for item in "${missing[@]}"; do
@@ -42,6 +52,13 @@ jobs:
             done
             exit 1
           fi
+
+      - name: Install AWS CLI
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != '' }}
+        uses: unfor19/install-aws-cli-action@v1
+
+      - name: Resolve production EC2 target
+        run: scripts/ci/resolve_ec2_target.sh
 
       - name: Package observability files
         run: |
@@ -64,11 +81,17 @@ jobs:
           chmod 600 "${key_file}"
           remote_observability_dir="$(printf '%q' "${OBSERVABILITY_DIR}")"
           remote_grafana_password="$(printf '%q' "${GRAFANA_ADMIN_PASSWORD}")"
+          ssh_opts=(-o StrictHostKeyChecking=no -o LogLevel=ERROR -o BatchMode=yes -o ConnectTimeout=20 -o ConnectionAttempts=2 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes)
 
-          ssh -o StrictHostKeyChecking=no -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "mkdir -p ${remote_observability_dir}"
-          scp -o StrictHostKeyChecking=no -i "${key_file}" /tmp/observability-bundle.tgz "${EC2_USER}@${EC2_HOST}:${remote_observability_dir}/observability-bundle.tgz"
+          if ! ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "printf 'ssh-ok\n'"; then
+            echo "::error::Unable to reach production EC2 over SSH. Verify the resolved host, instance state, and security group ingress for GitHub-hosted runners on port 22."
+            exit 1
+          fi
 
-          ssh -o StrictHostKeyChecking=no -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "OBSERVABILITY_DIR=${remote_observability_dir} GRAFANA_ADMIN_PASSWORD=${remote_grafana_password} bash -s" <<'EOF'
+          ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "mkdir -p ${remote_observability_dir}"
+          scp "${ssh_opts[@]}" -i "${key_file}" /tmp/observability-bundle.tgz "${EC2_USER}@${EC2_HOST}:${remote_observability_dir}/observability-bundle.tgz"
+
+          ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "OBSERVABILITY_DIR=${remote_observability_dir} GRAFANA_ADMIN_PASSWORD=${remote_grafana_password} bash -s" <<'EOF'
           set -euo pipefail
 
           OBS_DIR="${OBSERVABILITY_DIR:-/home/ubuntu/smart-tutor-observability}"
@@ -248,6 +271,24 @@ jobs:
             "${compose_cmd[@]}" logs --tail=200 || true
           }
 
+          start_heartbeat() {
+            (
+              while true; do
+                sleep 60
+                echo "[KEEPALIVE] Observability bootstrap still running at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              done
+            ) &
+            heartbeat_pid="$!"
+          }
+
+          stop_heartbeat() {
+            if [ -n "${heartbeat_pid:-}" ]; then
+              kill "${heartbeat_pid}" 2>/dev/null || true
+              wait "${heartbeat_pid}" 2>/dev/null || true
+            fi
+          }
+          trap stop_heartbeat EXIT
+
           require_prometheus_target_health() {
             local expected_jobs_csv="$1"
             local attempts="${2:-12}"
@@ -389,7 +430,9 @@ jobs:
             echo "[PASS] PostHog host reachable: ${posthog_host} (HTTP ${http_code})"
           }
 
+          start_heartbeat
           "${compose_cmd[@]}" up -d --remove-orphans
+          stop_heartbeat
 
           # Prometheus and Alertmanager read bind-mounted config files only at startup.
           # Restart them so each bootstrap run picks up the freshly rendered config.
@@ -439,6 +482,10 @@ jobs:
 
           "${compose_cmd[@]}" ps
           EOF
+
+      - name: Revoke temporary SSH ingress
+        if: always()
+        run: scripts/ci/revoke_ec2_ssh_ingress.sh
 
       - name: Summary
         run: |

--- a/.github/workflows/rag-evaluation-scheduled.yml
+++ b/.github/workflows/rag-evaluation-scheduled.yml
@@ -48,7 +48,21 @@ jobs:
     name: Run Dataset Evaluation
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID || '' }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY || '' }}
+      EC2_HOST: ${{ secrets.EC2_HOST || '' }}
+      EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID || vars.EC2_INSTANCE_ID || '' }}
+      EC2_INSTANCE_NAME: ${{ vars.EC2_INSTANCE_NAME || '' }}
+      EC2_AUTO_START: ${{ vars.EC2_AUTO_START || 'true' }}
+      EC2_TEMPORARY_SSH_INGRESS: ${{ vars.EC2_TEMPORARY_SSH_INGRESS || 'true' }}
+      EC2_USER: ${{ secrets.EC2_USER || '' }}
+      EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY || '' }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       # -----------------------------------------------------------------------
       # Step 1 — Validate required configuration before doing any network work
       # -----------------------------------------------------------------------
@@ -84,6 +98,14 @@ jobs:
 
           echo "✓ All required secrets are present."
 
+      - name: Install AWS CLI
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != '' && (env.EC2_HOST != '' || env.EC2_INSTANCE_ID != '' || env.EC2_INSTANCE_NAME != '') }}
+        uses: unfor19/install-aws-cli-action@v1
+
+      - name: Resolve production EC2 target
+        if: ${{ env.EC2_HOST != '' || env.EC2_INSTANCE_ID != '' || env.EC2_INSTANCE_NAME != '' }}
+        run: scripts/ci/resolve_ec2_target.sh
+
       # -----------------------------------------------------------------------
       # Step 2 — Build payload and call the backend
       # -----------------------------------------------------------------------
@@ -91,9 +113,6 @@ jobs:
         env:
           EVALUATION_BACKEND_URL: ${{ secrets.EVALUATION_BACKEND_URL || vars.EVALUATION_BACKEND_URL_PROD }}
           EVALUATION_CRON_TOKEN: ${{ secrets.EVALUATION_CRON_TOKEN }}
-          EC2_HOST: ${{ secrets.EC2_HOST || '' }}
-          EC2_USER: ${{ secrets.EC2_USER || '' }}
-          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY || '' }}
           REQUESTED_EVALUATION_DATASET_LIMIT: ${{ inputs.dataset_limit || '' }}
           DEFAULT_EVALUATION_DATASET_LIMIT: ${{ vars.EVALUATION_DATASET_LIMIT || '20' }}
           SCHEDULED_EVALUATION_DATASET_LIMIT: ${{ vars.EVALUATION_SCHEDULED_DATASET_LIMIT || '5' }}
@@ -183,14 +202,20 @@ jobs:
             key_file="$(mktemp)"
             printf '%s\n' "${EC2_SSH_KEY}" > "${key_file}"
             chmod 600 "${key_file}"
+            local ssh_opts
+            ssh_opts=(-o StrictHostKeyChecking=no -o LogLevel=ERROR -o BatchMode=yes -o ConnectTimeout=20 -o ConnectionAttempts=2 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes)
 
             model_arg=""
             if [ -n "${EVALUATION_MODEL_ID}" ]; then
               model_arg="--model-id ${EVALUATION_MODEL_ID}"
             fi
 
-            if ssh -o StrictHostKeyChecking=no -i "${key_file}" "${EC2_USER}@${EC2_HOST}" \
-              -o LogLevel=ERROR -o ServerAliveInterval=30 -o ServerAliveCountMax=10 \
+            if ! ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "printf 'ssh-ok\n'" >/dev/null 2>/tmp/eval_fallback_error.log; then
+              rm -f "${key_file}"
+              return 1
+            fi
+
+            if ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" \
               "DATASET_LIMIT='${dataset_limit}' EVALUATION_TIMEOUT='${INTERNAL_EVALUATION_TIMEOUT_SECONDS}' MODEL_ARG='${model_arg}' bash -lc '
                 set -euo pipefail
                 for _ in 1 2 3 4 5 6; do
@@ -286,12 +311,14 @@ jobs:
             # Write clean summary using the isolated final result object
             jq \
               --arg http_code "${http_code}" \
+              --arg response_source "${response_source}" \
               --arg dataset_limit "${dataset_limit}" \
               --arg min_avg_correctness "${MIN_AVG_CORRECTNESS}" \
               --arg min_avg_context_recall "${MIN_AVG_CONTEXT_RECALL}" \
               --arg max_avg_drift_score "${MAX_AVG_DRIFT_SCORE}" \
               '{
                 http_code: $http_code,
+                response_source: $response_source,
                 dataset_limit: ($dataset_limit | tonumber),
                 thresholds: {
                   min_avg_correctness: ($min_avg_correctness | tonumber),
@@ -301,7 +328,25 @@ jobs:
                 response: .
               }' /tmp/eval_final_result.json > /tmp/eval_summary.json
           else
-            printf '%s\n' "{\"http_code\":\"${http_code}\",\"dataset_limit\":\"${dataset_limit}\",\"response_is_json\":false}" > /tmp/eval_summary.json
+            jq -n \
+              --arg http_code "${http_code}" \
+              --arg response_source "${response_source}" \
+              --arg dataset_limit "${dataset_limit}" \
+              --arg min_avg_correctness "${MIN_AVG_CORRECTNESS}" \
+              --arg min_avg_context_recall "${MIN_AVG_CONTEXT_RECALL}" \
+              --arg max_avg_drift_score "${MAX_AVG_DRIFT_SCORE}" \
+              '{
+                http_code: $http_code,
+                response_source: $response_source,
+                dataset_limit: ($dataset_limit | tonumber),
+                response_is_json: false,
+                thresholds: {
+                  min_avg_correctness: ($min_avg_correctness | tonumber),
+                  min_avg_context_recall: ($min_avg_context_recall | tonumber),
+                  max_avg_drift_score: ($max_avg_drift_score | tonumber)
+                },
+                response: null
+              }' > /tmp/eval_summary.json
           fi
 
           # ── Write Job Summary ──────────────────────────────────────────────
@@ -412,6 +457,10 @@ jobs:
           fi
           echo "✓ Evaluation triggered successfully (HTTP ${http_code})."
 
+      - name: Revoke temporary SSH ingress
+        if: always()
+        run: scripts/ci/revoke_ec2_ssh_ingress.sh
+
       - name: Upload evaluation response artifact
         if: always()
         uses: actions/upload-artifact@v4
@@ -436,7 +485,6 @@ jobs:
         with:
           name: rag-evaluation-response-${{ github.run_id }}
           path: /tmp
-          if-no-files-found: warning
 
       - name: Resolve quality metrics
         id: notify-vars
@@ -446,28 +494,53 @@ jobs:
           eval_result="${{ needs.run-dataset-evaluation.result }}"
           overall_status="success"
           quality_gate="PASSED"
+          notify_message=":white_check_mark: *RAG evaluation completed*"
+          failure_detail=""
+          http_code="unknown"
+          response_source="unknown"
           avg_correctness="unknown"
           avg_context_recall="unknown"
           avg_drift_score="unknown"
           total_evaluated="unknown"
+          avg_c=""
 
-          if [ "${eval_result}" = "failure" ]; then
-            overall_status="failure"
-            quality_gate="FAILED"
-          elif [ -f /tmp/eval_summary.json ]; then
-            # Use -r to get raw strings without quotes; use || true to handle empty
+          if [ -f /tmp/eval_summary.json ]; then
+            http_code="$(jq -r '.http_code // "unknown"' /tmp/eval_summary.json 2>/dev/null || echo "unknown")"
+            response_source="$(jq -r '.response_source // "unknown"' /tmp/eval_summary.json 2>/dev/null || echo "unknown")"
             avg_c="$(jq -r '.response.quality_summary.avg_correctness // empty' /tmp/eval_summary.json 2>/dev/null || true)"
             avg_correctness="$(jq -r '.response.quality_summary.avg_correctness // "unknown"' /tmp/eval_summary.json 2>/dev/null || echo "unknown")"
             avg_context_recall="$(jq -r '.response.quality_summary.avg_context_recall // "unknown"' /tmp/eval_summary.json 2>/dev/null || echo "unknown")"
             avg_drift_score="$(jq -r '.response.drift_summary.avg_drift_score // "unknown"' /tmp/eval_summary.json 2>/dev/null || echo "unknown")"
             total_evaluated="$(jq -r '.response.total_evaluated // "unknown"' /tmp/eval_summary.json 2>/dev/null || echo "unknown")"
-            # Compare using awk (handles floats reliably); only compare when avg_c is a non-empty number
+          fi
+
+          if [ "${eval_result}" = "failure" ]; then
+            overall_status="failure"
+            quality_gate="FAILED"
+            if [ "${http_code}" != "unknown" ]; then
+              failure_detail="Backend returned HTTP ${http_code} via ${response_source}."
+            else
+              failure_detail="Dataset evaluation job failed before metrics were available."
+            fi
+            printf -v notify_message ':x: *RAG evaluation FAILED*\n%s\nQuality gate: *%s*' \
+              "${failure_detail}" \
+              "${quality_gate}"
+          else
             if [ -n "${avg_c}" ] && [ "${avg_c}" != "null" ] && [ "${avg_c}" != "unknown" ]; then
               is_below="$(awk "BEGIN {print ("${avg_c}" < 0.55) ? 1 : 0}")"
               if [ "${is_below}" -eq 1 ]; then
                 overall_status="warning"
                 quality_gate="BELOW_THRESHOLD"
               fi
+            fi
+            if [ "${overall_status}" = "warning" ]; then
+              printf -v notify_message ':warning: *RAG evaluation completed below threshold*\nQuality gate: *%s* | Evaluated: %s questions' \
+                "${quality_gate}" \
+                "${total_evaluated}"
+            else
+              printf -v notify_message ':white_check_mark: *RAG evaluation completed*\nQuality gate: *%s* | Evaluated: %s questions' \
+                "${quality_gate}" \
+                "${total_evaluated}"
             fi
           fi
 
@@ -483,6 +556,13 @@ jobs:
           echo "avg_context_recall=$(escape "${avg_context_recall}")" >> "$GITHUB_OUTPUT"
           echo "avg_drift_score=$(escape "${avg_drift_score}")" >> "$GITHUB_OUTPUT"
           echo "total_evaluated=$(escape "${total_evaluated}")" >> "$GITHUB_OUTPUT"
+          echo "http_code=$(escape "${http_code}")" >> "$GITHUB_OUTPUT"
+          echo "response_source=$(escape "${response_source}")" >> "$GITHUB_OUTPUT"
+          {
+            echo "message<<EOF"
+            printf '%s\n' "${notify_message}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout for Slack notify
         if: always()
@@ -497,11 +577,11 @@ jobs:
           workflow_name: Scheduled RAG Evaluation
           status: ${{ steps.notify-vars.outputs.status }}
           verbiage: RAG Eval
-          message: |
-            :white_check_mark: *RAG evaluation completed*
-            Quality gate: *${{ steps.notify-vars.outputs.quality_gate }}*
+          message: ${{ steps.notify-vars.outputs.message }}
           fields: >-
             [
+              {"title": "HTTP Status", "value": "${{ steps.notify-vars.outputs.http_code }}", "short": true},
+              {"title": "Response Source", "value": "${{ steps.notify-vars.outputs.response_source }}", "short": true},
               {"title": "Avg Correctness", "value": "${{ steps.notify-vars.outputs.avg_correctness }}", "short": true},
               {"title": "Avg Context Recall", "value": "${{ steps.notify-vars.outputs.avg_context_recall }}", "short": true},
               {"title": "Avg Drift Score", "value": "${{ steps.notify-vars.outputs.avg_drift_score }}", "short": true},
@@ -519,11 +599,11 @@ jobs:
           workflow_name: Scheduled RAG Evaluation
           status: ${{ steps.notify-vars.outputs.status }}
           verbiage: RAG Eval
-          message: |
-            :white_check_mark: *RAG evaluation completed*
-            Quality gate: *${{ steps.notify-vars.outputs.quality_gate }}* | Evaluated: ${{ steps.notify-vars.outputs.total_evaluated }} questions
+          message: ${{ steps.notify-vars.outputs.message }}
           fields: >-
             [
+              {"title": "HTTP Status", "value": "${{ steps.notify-vars.outputs.http_code }}", "short": true},
+              {"title": "Response Source", "value": "${{ steps.notify-vars.outputs.response_source }}", "short": true},
               {"title": "Avg Correctness", "value": "${{ steps.notify-vars.outputs.avg_correctness }}", "short": true},
               {"title": "Avg Context Recall", "value": "${{ steps.notify-vars.outputs.avg_context_recall }}", "short": true},
               {"title": "Avg Drift Score", "value": "${{ steps.notify-vars.outputs.avg_drift_score }}", "short": true},

--- a/backend/agents/neo4j_client.py
+++ b/backend/agents/neo4j_client.py
@@ -53,6 +53,7 @@ def _get_aura_token() -> Optional[str]:
         resp = requests.post(
             f"{AURA_API_BASE}/oauth/token",
             auth=(config.NEO4J_AURA_API_CLIENT_ID, config.NEO4J_AURA_API_CLIENT_SECRET),
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
             data={"grant_type": "client_credentials"},
             timeout=10,
         )
@@ -87,7 +88,8 @@ def _get_instance_status() -> Optional[str]:
         )
         resp.raise_for_status()
         data = resp.json()
-        status = data.get("data", {}).get("status", "unknown")
+        instance = data.get("data", data)
+        status = str(instance.get("status") or instance.get("state") or "unknown").lower()
         logger.info("Aura instance %s status: %s", config.NEO4J_AURA_INSTANCE_ID, status)
         return status
     except Exception as exc:
@@ -126,6 +128,7 @@ def _resume_aura_instance(max_wait: int = 120) -> bool:
                         "Authorization": f"Bearer {token}",
                         "Content-Type": "application/json",
                     },
+                    json={},
                     timeout=10,
                 )
                 resp.raise_for_status()

--- a/backend/config.py
+++ b/backend/config.py
@@ -479,8 +479,8 @@ class Config:
 
     # Neo4j Aura API (for auto-resume of paused instances)
     NEO4J_AURA_INSTANCE_ID = os.getenv("NEO4J_AURA_INSTANCE_ID", "")
-    NEO4J_AURA_API_CLIENT_ID = os.getenv("NEO4J_AURA_API_CLIENT_ID", "")
-    NEO4J_AURA_API_CLIENT_SECRET = os.getenv("NEO4J_AURA_API_CLIENT_SECRET", "")
+    NEO4J_AURA_API_CLIENT_ID = os.getenv("NEO4J_AURA_API_CLIENT_ID") or os.getenv("NEO4J_AURA_CLIENT_ID", "")
+    NEO4J_AURA_API_CLIENT_SECRET = os.getenv("NEO4J_AURA_API_CLIENT_SECRET") or os.getenv("NEO4J_AURA_CLIENT_SECRET", "")
 
     # LLM Routing (Complexity-Based Model Selection)
     LLM_ROUTING_ENABLED = os.getenv("LLM_ROUTING_ENABLED", "false").lower() == "true"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -127,6 +127,7 @@ Authentication and OAuth setup.
 | Script | Purpose |
 |--------|---------|
 | `manage_services.sh` | Start/stop/restart services |
+| `resume_neo4j_aura.py` | Resume a paused Neo4j Aura instance via the Aura API |
 
 ---
 

--- a/scripts/ci/resolve_ec2_target.sh
+++ b/scripts/ci/resolve_ec2_target.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the production EC2 host before SSH-based workflows run.
+#
+# Inputs:
+#   EC2_HOST                 Optional static public IP/DNS fallback.
+#   EC2_INSTANCE_ID          Preferred AWS instance id.
+#   EC2_INSTANCE_NAME        Optional Name tag fallback.
+#   EC2_AUTO_START           true/false; starts stopped instances when possible.
+#   EC2_TEMPORARY_SSH_INGRESS true/false; temporarily allow this runner on SSH.
+#   AWS_REGION               AWS region for EC2 queries.
+#
+# Outputs:
+#   Exports EC2_HOST and EC2_RESOLVED_* values through GITHUB_ENV when present.
+
+AWS_REGION="${AWS_REGION:-us-east-1}"
+EC2_HOST="${EC2_HOST:-}"
+EC2_INSTANCE_ID="${EC2_INSTANCE_ID:-}"
+EC2_INSTANCE_NAME="${EC2_INSTANCE_NAME:-}"
+EC2_AUTO_START="$(printf '%s' "${EC2_AUTO_START:-true}" | tr '[:upper:]' '[:lower:]')"
+EC2_TEMPORARY_SSH_INGRESS="$(printf '%s' "${EC2_TEMPORARY_SSH_INGRESS:-true}" | tr '[:upper:]' '[:lower:]')"
+
+write_env() {
+  local name="$1"
+  local value="$2"
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    printf '%s=%s\n' "${name}" "${value}" >> "${GITHUB_ENV}"
+  fi
+  export "${name}=${value}"
+}
+
+write_output() {
+  local name="$1"
+  local value="$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "${name}" "${value}" >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+mask_value() {
+  local value="$1"
+  if [ -n "${value}" ] && [ "${value}" != "None" ]; then
+    echo "::add-mask::${value}"
+  fi
+}
+
+if ! command -v aws >/dev/null 2>&1; then
+  if [ -n "${EC2_HOST}" ]; then
+    echo "::warning::AWS CLI is unavailable; using EC2_HOST as provided."
+    write_env "EC2_HOST" "${EC2_HOST}"
+    write_output "host" "${EC2_HOST}"
+    exit 0
+  fi
+
+  echo "::error::AWS CLI is unavailable and EC2_HOST is not set."
+  exit 1
+fi
+
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+  if [ -n "${EC2_HOST}" ]; then
+    echo "::warning::AWS credentials are unavailable; using EC2_HOST as provided."
+    write_env "EC2_HOST" "${EC2_HOST}"
+    write_output "host" "${EC2_HOST}"
+    exit 0
+  fi
+
+  echo "::error::AWS credentials are unavailable and EC2_HOST is not set."
+  exit 1
+fi
+
+describe_instance() {
+  if [ -n "${EC2_INSTANCE_ID}" ]; then
+    aws ec2 describe-instances \
+      --region "${AWS_REGION}" \
+      --instance-ids "${EC2_INSTANCE_ID}" \
+      --query 'Reservations[0].Instances[0].[InstanceId,State.Name,PublicIpAddress,PrivateIpAddress,PublicDnsName,join(`,`,SecurityGroups[].GroupId)]' \
+      --output text 2>/tmp/ec2-describe-error.log
+    return
+  fi
+
+  if [ -n "${EC2_INSTANCE_NAME}" ]; then
+    aws ec2 describe-instances \
+      --region "${AWS_REGION}" \
+      --filters \
+        "Name=tag:Name,Values=${EC2_INSTANCE_NAME}" \
+        "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+      --query 'Reservations[0].Instances[0].[InstanceId,State.Name,PublicIpAddress,PrivateIpAddress,PublicDnsName,join(`,`,SecurityGroups[].GroupId)]' \
+      --output text 2>/tmp/ec2-describe-error.log
+    return
+  fi
+
+  if [ -n "${EC2_HOST}" ]; then
+    aws ec2 describe-instances \
+      --region "${AWS_REGION}" \
+      --filters \
+        "Name=ip-address,Values=${EC2_HOST}" \
+        "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+      --query 'Reservations[0].Instances[0].[InstanceId,State.Name,PublicIpAddress,PrivateIpAddress,PublicDnsName,join(`,`,SecurityGroups[].GroupId)]' \
+      --output text 2>/tmp/ec2-describe-error.log
+    return
+  fi
+
+  return 1
+}
+
+if ! instance_row="$(describe_instance)"; then
+  if [ -s /tmp/ec2-describe-error.log ]; then
+    cat /tmp/ec2-describe-error.log >&2
+  fi
+  if [ -n "${EC2_HOST}" ]; then
+    echo "::warning::Could not resolve EC2 metadata; using EC2_HOST as provided."
+    write_env "EC2_HOST" "${EC2_HOST}"
+    write_output "host" "${EC2_HOST}"
+    exit 0
+  fi
+  echo "::error::Could not resolve EC2 target. Set EC2_HOST or EC2_INSTANCE_ID."
+  exit 1
+fi
+
+if [ -z "${instance_row}" ] || [ "${instance_row}" = "None" ]; then
+  if [ -n "${EC2_HOST}" ]; then
+    echo "::warning::No EC2 instance matched the configured selector; using EC2_HOST as provided."
+    write_env "EC2_HOST" "${EC2_HOST}"
+    write_output "host" "${EC2_HOST}"
+    exit 0
+  fi
+  echo "::error::No EC2 instance matched the configured selector."
+  exit 1
+fi
+
+read -r resolved_instance_id resolved_state public_ip private_ip public_dns security_group_ids <<< "${instance_row}"
+public_ip="${public_ip/None/}"
+private_ip="${private_ip/None/}"
+public_dns="${public_dns/None/}"
+security_group_ids="${security_group_ids/None/}"
+
+if [ "${resolved_state}" = "stopped" ]; then
+  if [ "${EC2_AUTO_START}" = "true" ]; then
+    echo "Production EC2 instance is stopped; starting it before workflow SSH."
+    aws ec2 start-instances --region "${AWS_REGION}" --instance-ids "${resolved_instance_id}" >/dev/null
+    aws ec2 wait instance-running --region "${AWS_REGION}" --instance-ids "${resolved_instance_id}"
+    instance_row="$(EC2_INSTANCE_ID="${resolved_instance_id}" describe_instance)"
+    read -r resolved_instance_id resolved_state public_ip private_ip public_dns security_group_ids <<< "${instance_row}"
+    public_ip="${public_ip/None/}"
+    private_ip="${private_ip/None/}"
+    public_dns="${public_dns/None/}"
+    security_group_ids="${security_group_ids/None/}"
+  else
+    echo "::error::Production EC2 instance is stopped. Set EC2_AUTO_START=true or start it manually."
+    exit 1
+  fi
+fi
+
+if [ "${resolved_state}" != "running" ]; then
+  echo "::error::Production EC2 instance is not running. Current state: ${resolved_state}"
+  exit 1
+fi
+
+resolved_host="${public_ip:-${public_dns:-${EC2_HOST}}}"
+if [ -z "${resolved_host}" ]; then
+  echo "::error::Resolved EC2 instance is running but has no public host."
+  exit 1
+fi
+
+mask_value "${resolved_host}"
+mask_value "${public_ip}"
+mask_value "${private_ip}"
+mask_value "${public_dns}"
+
+write_env "EC2_HOST" "${resolved_host}"
+write_env "EC2_RESOLVED_INSTANCE_ID" "${resolved_instance_id}"
+write_env "EC2_RESOLVED_STATE" "${resolved_state}"
+write_env "EC2_RESOLVED_PUBLIC_IP" "${public_ip}"
+write_env "EC2_RESOLVED_PRIVATE_IP" "${private_ip}"
+write_env "EC2_RESOLVED_SECURITY_GROUP_IDS" "${security_group_ids}"
+write_output "host" "${resolved_host}"
+write_output "instance_id" "${resolved_instance_id}"
+write_output "state" "${resolved_state}"
+
+if [ "${EC2_TEMPORARY_SSH_INGRESS}" = "true" ] && [ -n "${security_group_ids}" ]; then
+  if command -v curl >/dev/null 2>&1 && runner_ip="$(curl -fsS --max-time 10 https://checkip.amazonaws.com | tr -d '[:space:]')"; then
+    if [[ "${runner_ip}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      runner_cidr="${runner_ip}/32"
+      mask_value "${runner_cidr}"
+      for group_id in ${security_group_ids//,/ }; do
+        if aws ec2 authorize-security-group-ingress \
+          --region "${AWS_REGION}" \
+          --group-id "${group_id}" \
+          --protocol tcp \
+          --port 22 \
+          --cidr "${runner_cidr}" >/tmp/ec2-authorize-ssh.log 2>&1; then
+          echo "Temporarily authorized this GitHub runner for SSH."
+        elif grep -q "InvalidPermission.Duplicate" /tmp/ec2-authorize-ssh.log; then
+          echo "Temporary SSH ingress already exists for this GitHub runner."
+        else
+          cat /tmp/ec2-authorize-ssh.log >&2
+          echo "::warning::Unable to add temporary SSH ingress to ${group_id}; SSH may still fail."
+        fi
+      done
+      write_env "EC2_TEMP_SSH_CIDR" "${runner_cidr}"
+      write_env "EC2_TEMP_SSH_SECURITY_GROUP_IDS" "${security_group_ids}"
+    else
+      echo "::warning::Could not determine a valid GitHub runner IPv4 address for temporary SSH ingress."
+    fi
+  else
+    echo "::warning::Could not determine GitHub runner public IP for temporary SSH ingress."
+  fi
+fi
+
+echo "Resolved production EC2 target from AWS metadata."

--- a/scripts/ci/revoke_ec2_ssh_ingress.sh
+++ b/scripts/ci/revoke_ec2_ssh_ingress.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AWS_REGION="${AWS_REGION:-us-east-1}"
+cidr="${EC2_TEMP_SSH_CIDR:-}"
+security_group_ids="${EC2_TEMP_SSH_SECURITY_GROUP_IDS:-}"
+
+if [ -z "${cidr}" ] || [ -z "${security_group_ids}" ]; then
+  echo "No temporary EC2 SSH ingress rule recorded; nothing to revoke."
+  exit 0
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "::warning::AWS CLI is unavailable; cannot revoke temporary SSH ingress."
+  exit 0
+fi
+
+for group_id in ${security_group_ids//,/ }; do
+  if aws ec2 revoke-security-group-ingress \
+    --region "${AWS_REGION}" \
+    --group-id "${group_id}" \
+    --protocol tcp \
+    --port 22 \
+    --cidr "${cidr}" >/tmp/ec2-revoke-ssh.log 2>&1; then
+    echo "Revoked temporary SSH ingress from ${group_id}."
+  elif grep -Eq "InvalidPermission.NotFound|InvalidPermission.Malformed" /tmp/ec2-revoke-ssh.log; then
+    echo "Temporary SSH ingress was already absent from ${group_id}."
+  else
+    cat /tmp/ec2-revoke-ssh.log >&2
+    echo "::warning::Unable to revoke temporary SSH ingress from ${group_id}."
+  fi
+done

--- a/scripts/resume_neo4j_aura.py
+++ b/scripts/resume_neo4j_aura.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Resume a paused Neo4j Aura instance.
+
+This script is intentionally dependency-free so it can run from GitHub Actions
+or a small host cron without installing the application requirements.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+DEFAULT_API_BASE_URL = "https://api.neo4j.io/v1"
+DEFAULT_TOKEN_URL = "https://api.neo4j.io/oauth/token"
+
+RUNNING_STATES = {"running", "ready"}
+PAUSED_STATES = {"paused", "stopped"}
+WAIT_STATES = {"resuming", "starting", "creating", "updating", "pending"}
+
+
+class AuraApiError(RuntimeError):
+    """Raised when the Aura API returns an unexpected response."""
+
+
+def _env(*names: str) -> str:
+    for name in names:
+        value = os.getenv(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _write_output(name: str, value: str) -> None:
+    output_path = os.getenv("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a", encoding="utf-8") as handle:
+        handle.write(f"{name}={value}\n")
+
+
+def _request_json(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    body: bytes | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    request = urllib.request.Request(url, data=body, headers=headers or {}, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        raw_body = exc.read().decode("utf-8", "replace")
+        detail = raw_body[:500] if raw_body else exc.reason
+        raise AuraApiError(f"{method} {url} failed with HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise AuraApiError(f"{method} {url} failed: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise AuraApiError(f"{method} {url} returned non-JSON response") from exc
+
+
+def get_access_token(client_id: str, client_secret: str, token_url: str) -> str:
+    credentials = f"{client_id}:{client_secret}".encode("utf-8")
+    auth = base64.b64encode(credentials).decode("ascii")
+    body = urllib.parse.urlencode({"grant_type": "client_credentials"}).encode("utf-8")
+    data = _request_json(
+        "POST",
+        token_url,
+        headers={
+            "Authorization": f"Basic {auth}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body=body,
+    )
+    token = data.get("access_token")
+    if not isinstance(token, str) or not token:
+        raise AuraApiError("Aura token response did not include access_token")
+    return token
+
+
+def _instance_payload(response: dict[str, Any]) -> dict[str, Any]:
+    data = response.get("data")
+    return data if isinstance(data, dict) else response
+
+
+def _status(instance: dict[str, Any]) -> str:
+    raw = instance.get("status") or instance.get("state") or "unknown"
+    return str(raw).strip().lower()
+
+
+def get_instance(api_base_url: str, instance_id: str, token: str) -> dict[str, Any]:
+    response = _request_json(
+        "GET",
+        f"{api_base_url.rstrip('/')}/instances/{instance_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    return _instance_payload(response)
+
+
+def resume_instance(api_base_url: str, instance_id: str, token: str) -> dict[str, Any]:
+    response = _request_json(
+        "POST",
+        f"{api_base_url.rstrip('/')}/instances/{instance_id}/resume",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        body=b"{}",
+    )
+    return _instance_payload(response)
+
+
+def wait_until_running(
+    api_base_url: str,
+    instance_id: str,
+    token: str,
+    *,
+    timeout_seconds: int,
+    interval_seconds: int,
+) -> tuple[str, dict[str, Any]]:
+    deadline = time.monotonic() + timeout_seconds
+    last_instance: dict[str, Any] = {}
+    last_status = "unknown"
+
+    while time.monotonic() < deadline:
+        last_instance = get_instance(api_base_url, instance_id, token)
+        last_status = _status(last_instance)
+        print(f"Aura instance {instance_id} status: {last_status}", flush=True)
+        if last_status in RUNNING_STATES:
+            return last_status, last_instance
+        time.sleep(interval_seconds)
+
+    return last_status, last_instance
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Resume a paused Neo4j Aura instance.")
+    parser.add_argument("--instance-id", default=_env("NEO4J_AURA_INSTANCE_ID"))
+    parser.add_argument("--api-base-url", default=_env("NEO4J_AURA_API_BASE_URL") or DEFAULT_API_BASE_URL)
+    parser.add_argument("--token-url", default=_env("NEO4J_AURA_TOKEN_URL") or DEFAULT_TOKEN_URL)
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=int(_env("NEO4J_AURA_POLL_TIMEOUT_SECONDS") or "420"),
+        help="Seconds to wait for the instance to become running.",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=int(_env("NEO4J_AURA_POLL_INTERVAL_SECONDS") or "15"),
+        help="Seconds between status polls.",
+    )
+    parser.add_argument("--no-wait", action="store_true", help="Request resume but do not poll for running status.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    client_id = _env("NEO4J_AURA_CLIENT_ID", "NEO4J_AURA_API_CLIENT_ID")
+    client_secret = _env("NEO4J_AURA_CLIENT_SECRET", "NEO4J_AURA_API_CLIENT_SECRET")
+
+    missing = []
+    if not args.instance_id:
+        missing.append("NEO4J_AURA_INSTANCE_ID")
+    if not client_id:
+        missing.append("NEO4J_AURA_CLIENT_ID")
+    if not client_secret:
+        missing.append("NEO4J_AURA_CLIENT_SECRET")
+    if missing:
+        print(f"Missing required configuration: {', '.join(missing)}", file=sys.stderr)
+        _write_output("action", "configuration_missing")
+        _write_output("status", "unknown")
+        return 2
+
+    action = "checked"
+    status = "unknown"
+    instance_name = ""
+
+    try:
+        token = get_access_token(client_id, client_secret, args.token_url)
+        instance = get_instance(args.api_base_url, args.instance_id, token)
+        status = _status(instance)
+        instance_name = str(instance.get("name") or "")
+        print(f"Aura instance {args.instance_id} initial status: {status}", flush=True)
+
+        if status in RUNNING_STATES:
+            action = "already_running"
+            print("No resume needed.")
+            return 0
+
+        if status in PAUSED_STATES:
+            action = "resume_requested"
+            resumed = resume_instance(args.api_base_url, args.instance_id, token)
+            status = _status(resumed)
+            instance_name = str(resumed.get("name") or instance_name)
+            print(f"Resume requested for {args.instance_id}; API status is now {status}.", flush=True)
+        elif status in WAIT_STATES:
+            action = "waited_for_running"
+            print(f"Instance is already transitioning ({status}); waiting for running status.", flush=True)
+        else:
+            raise AuraApiError(f"Instance is in an unsupported state for auto-resume: {status}")
+
+        if not args.no_wait:
+            status, instance = wait_until_running(
+                args.api_base_url,
+                args.instance_id,
+                token,
+                timeout_seconds=args.timeout,
+                interval_seconds=args.interval,
+            )
+            instance_name = str(instance.get("name") or instance_name)
+
+        if status not in RUNNING_STATES:
+            raise AuraApiError(f"Instance did not become running before timeout; last status: {status}")
+
+        action = "resumed" if action == "resume_requested" else action
+        print(f"Aura instance {args.instance_id} is running.")
+        return 0
+    except Exception as exc:
+        print(f"Neo4j Aura resume failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        _write_output("action", action)
+        _write_output("status", status)
+        _write_output("instance_id", args.instance_id)
+        _write_output("instance_name", instance_name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add EC2 target resolution and temporary runner SSH ingress for production SSH workflows
- Add cleanup for temporary EC2 SSH ingress rules
- Add Neo4j Aura resume guard and harden Aura auto-resume config
- Update observability, compliance, and RAG scheduled workflows to avoid stale EC2 host failures

## Validation
- bash -n scripts/ci/resolve_ec2_target.sh scripts/ci/revoke_ec2_ssh_ingress.sh
- python3 -m py_compile scripts/resume_neo4j_aura.py backend/agents/neo4j_client.py backend/config.py
- ruby YAML parse for updated workflows
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic resumption of paused Neo4j Aura instances on a scheduled basis.
  * Enhanced CI/CD workflows with improved EC2 infrastructure detection and SSH connectivity validation.
  * Implemented automatic temporary SSH access provisioning and cleanup for CI operations.

* **Chores**
  * Updated configuration to support Neo4j Aura credentials for instance management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liteshperumalla/Smart-Tutor-AI-AI-Driven-Personalized-Teaching-Support/pull/28)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->