### PR TITLE
Fix scheduled CI/CD pipeline failure handling

### DIFF
--- a/.github/workflows/compliance-production.yml
+++ b/.github/workflows/compliance-production.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      skipped_reason: ${{ steps.remote-checks.outputs.skipped_reason }}
     env:
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -27,6 +29,7 @@ jobs:
       EC2_USER: ${{ secrets.EC2_USER }}
       EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
       EC2_APP_DIR: ${{ vars.EC2_APP_DIR || '' }}
+      COMPLIANCE_REQUIRE_EC2_SSH: ${{ vars.COMPLIANCE_REQUIRE_EC2_SSH || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -100,6 +103,7 @@ jobs:
           fi
 
       - name: Run remote EC2 compliance checks
+        id: remote-checks
         run: |
           set -euo pipefail
 
@@ -111,6 +115,14 @@ jobs:
           ssh_opts=(-o StrictHostKeyChecking=no -o LogLevel=ERROR -o BatchMode=yes -o ConnectTimeout=20 -o ConnectionAttempts=2 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes)
 
           if ! ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "printf 'ssh-ok\n'"; then
+            if [ "${{ github.event_name }}" = "schedule" ] && [ "$(printf '%s' "${COMPLIANCE_REQUIRE_EC2_SSH}" | tr '[:upper:]' '[:lower:]')" != "true" ]; then
+              echo "::warning::Production EC2 is not reachable over SSH from the GitHub runner. Skipping scheduled host compliance checks without failing the workflow."
+              echo "[INFO] Production EC2 SSH unavailable from GitHub runner; scheduled host checks skipped." > /tmp/compliance-report/ec2-host-checks.txt
+              echo "skipped_reason=ec2_ssh_unreachable" >> "$GITHUB_OUTPUT"
+              echo "EC2_SSH_REACHABLE=false" >> "$GITHUB_ENV"
+              rm -f "${key_file}"
+              exit 0
+            fi
             echo "::error::Unable to reach production EC2 over SSH. Verify the resolved host, instance state, and security group ingress for GitHub-hosted runners on port 22."
             exit 1
           fi
@@ -216,6 +228,11 @@ jobs:
       - name: Capture AWS compliance snapshot from EC2 fallback
         run: |
           set -uo pipefail
+
+          if [ "${EC2_SSH_REACHABLE:-true}" = "false" ]; then
+            echo "::warning::Skipping EC2 fallback snapshot because SSH was not reachable."
+            exit 0
+          fi
 
           mkdir -p /tmp/compliance-report
           mkdir -p /tmp/compliance-report/aws-fallback-needed
@@ -368,10 +385,10 @@ jobs:
           channel: SMART_TUTOR_AI
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_SMART_TUTOR_AI }}
           workflow_name: Production Compliance Scan
-          status: ${{ needs.compliance-scan.result == 'failure' && 'failure' || 'success' }}
+          status: ${{ needs.compliance-scan.outputs.skipped_reason != '' && 'warning' || (needs.compliance-scan.result == 'failure' && 'failure' || 'success') }}
           verbiage: Compliance
           message: |
-            ${{ needs.compliance-scan.result == 'failure' && ':x: *Compliance scan FAILED* — failed checks detected on production host.' || ':white_check_mark: *Compliance scan PASSED* — all host checks successful.' }}
+            ${{ needs.compliance-scan.outputs.skipped_reason != '' && ':warning: *Compliance scan skipped* — production EC2 was not reachable over SSH from the scheduled runner.' || (needs.compliance-scan.result == 'failure' && ':x: *Compliance scan FAILED* — failed checks detected on production host.' || ':white_check_mark: *Compliance scan completed* — host checks finished successfully.') }}
             ${{ github.event_name == 'schedule' && 'Weekly scheduled scan.' || 'Manual dispatch.' }}
           fields: >-
             [

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,6 +20,14 @@ env:
   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID || '' }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY || '' }}
+  EC2_HOST: ${{ secrets.EC2_HOST || '' }}
+  EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID || vars.EC2_INSTANCE_ID || '' }}
+  EC2_INSTANCE_NAME: ${{ vars.EC2_INSTANCE_NAME || '' }}
+  EC2_AUTO_START: ${{ vars.EC2_AUTO_START || 'true' }}
+  EC2_TEMPORARY_SSH_INGRESS: ${{ vars.EC2_TEMPORARY_SSH_INGRESS || 'true' }}
 
 concurrency:
   group: production-deploy
@@ -88,23 +96,33 @@ jobs:
 
       - name: Validate required deployment secrets
         env:
-          EC2_HOST: ${{ secrets.EC2_HOST }}
           EC2_USER: ${{ secrets.EC2_USER }}
           EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
         run: |
           set -euo pipefail
 
           missing_backend=()
-          for name in EC2_HOST EC2_USER EC2_SSH_KEY; do
+          for name in EC2_USER EC2_SSH_KEY; do
             if [ -z "${!name:-}" ]; then
               missing_backend+=("$name")
             fi
           done
+          if [ -z "${EC2_HOST:-}" ] && [ -z "${EC2_INSTANCE_ID:-}" ] && [ -z "${EC2_INSTANCE_NAME:-}" ]; then
+            missing_backend+=("EC2_HOST or EC2_INSTANCE_ID/EC2_INSTANCE_NAME")
+          fi
 
           if [ "${#missing_backend[@]}" -gt 0 ]; then
             echo "::error::Missing required backend deploy secrets: ${missing_backend[*]}"
             exit 1
           fi
+
+      - name: Install AWS CLI
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != '' }}
+        uses: unfor19/install-aws-cli-action@v1
+
+      - name: Resolve production EC2 target
+        id: ec2-target
+        run: scripts/ci/resolve_ec2_target.sh
 
       - name: Validate optional Vercel configuration
         run: |
@@ -243,7 +261,7 @@ jobs:
       - name: Transfer backend image bundle to EC2
         id: transfer_backend_image
         env:
-          EC2_HOST: ${{ secrets.EC2_HOST }}
+          EC2_HOST: ${{ steps.ec2-target.outputs.host }}
           EC2_USER: ${{ secrets.EC2_USER }}
           EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
           ARCHIVE_PATH: ${{ steps.export_backend_image.outputs.archive_path }}
@@ -256,9 +274,14 @@ jobs:
           chmod 600 "${key_file}"
 
           remote_archive="/tmp/${ARCHIVE_NAME}"
+          ssh_opts=(-o StrictHostKeyChecking=no -o LogLevel=ERROR -o BatchMode=yes -o ConnectTimeout=20 -o ConnectionAttempts=2 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes)
 
-          ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -o ServerAliveInterval=30 -o ServerAliveCountMax=10 \
-            -i "${key_file}" "${EC2_USER}@${EC2_HOST}" \
+          if ! ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "printf 'ssh-ok\n'"; then
+            echo "::error::Unable to reach production EC2 over SSH. Verify the resolved host, instance state, and security group ingress for GitHub-hosted runners on port 22."
+            exit 1
+          fi
+
+          ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" \
             "set -euo pipefail;
              rm -f /tmp/backend-image-*.tar.gz /tmp/backend-image-*.tar /tmp/drone-scp-* /tmp/*.tmp 2>/dev/null || true;
              docker image prune -af >/dev/null 2>&1 || true;
@@ -266,11 +289,9 @@ jobs:
              docker builder prune -af >/dev/null 2>&1 || true;
              df -h / /tmp || true"
 
-          scp -o StrictHostKeyChecking=no -o LogLevel=ERROR -o ServerAliveInterval=30 -o ServerAliveCountMax=10 \
-            -i "${key_file}" "${ARCHIVE_PATH}" "${EC2_USER}@${EC2_HOST}:${remote_archive}"
+          scp "${ssh_opts[@]}" -i "${key_file}" "${ARCHIVE_PATH}" "${EC2_USER}@${EC2_HOST}:${remote_archive}"
 
-          ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR -o ServerAliveInterval=30 -o ServerAliveCountMax=10 \
-            -i "${key_file}" "${EC2_USER}@${EC2_HOST}" \
+          ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" \
             "set -euo pipefail;
              test -f '${remote_archive}';
              ls -lh '${remote_archive}';
@@ -285,7 +306,7 @@ jobs:
           BACKEND_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-backend:${{ steps.version.outputs.version }}
           BACKEND_IMAGE_ARCHIVE: /tmp/${{ steps.export_backend_image.outputs.archive_name }}
         with:
-          host: ${{ secrets.EC2_HOST }}
+          host: ${{ steps.ec2-target.outputs.host }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           command_timeout: 75m
@@ -535,6 +556,10 @@ jobs:
 
             echo "=== Pruning all unused images/layers ==="
             docker_with_timeout 10m docker image prune -af || true
+
+      - name: Revoke temporary SSH ingress
+        if: always()
+        run: scripts/ci/revoke_ec2_ssh_ingress.sh
 
       - name: Deployment summary
         if: always()

--- a/.github/workflows/neo4j-aura-resume.yml
+++ b/.github/workflows/neo4j-aura-resume.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 12
     env:
       NEO4J_AURA_INSTANCE_ID: ${{ secrets.NEO4J_AURA_INSTANCE_ID || vars.NEO4J_AURA_INSTANCE_ID || 'b0e9fb13' }}
-      NEO4J_AURA_CLIENT_ID: ${{ secrets.NEO4J_AURA_CLIENT_ID || secrets.NEO4J_AURA_API_CLIENT_ID }}
-      NEO4J_AURA_CLIENT_SECRET: ${{ secrets.NEO4J_AURA_CLIENT_SECRET || secrets.NEO4J_AURA_API_CLIENT_SECRET }}
+      NEO4J_AURA_CLIENT_ID: ${{ secrets.NEO4J_AURA_CLIENT_ID || secrets.NEO4J_AURA_API_CLIENT_ID || secrets.AURA_CLIENT_ID || vars.NEO4J_AURA_CLIENT_ID || vars.NEO4J_AURA_API_CLIENT_ID || vars.AURA_CLIENT_ID || '' }}
+      NEO4J_AURA_CLIENT_SECRET: ${{ secrets.NEO4J_AURA_CLIENT_SECRET || secrets.NEO4J_AURA_API_CLIENT_SECRET || secrets.AURA_CLIENT_SECRET || '' }}
       NEO4J_AURA_POLL_TIMEOUT_SECONDS: ${{ vars.NEO4J_AURA_POLL_TIMEOUT_SECONDS || '420' }}
       NEO4J_AURA_POLL_INTERVAL_SECONDS: ${{ vars.NEO4J_AURA_POLL_INTERVAL_SECONDS || '15' }}
     steps:
@@ -50,7 +50,7 @@ jobs:
             [{"title":"Instance","value":"${{ steps.resume.outputs.instance_name || steps.resume.outputs.instance_id }}","short":true},{"title":"Status","value":"${{ steps.resume.outputs.status }}","short":true}]
 
       - name: Notify deployment analytics when Aura resume failed
-        if: ${{ steps.resume.outcome != 'success' }}
+        if: ${{ steps.resume.outcome != 'success' && steps.resume.outputs.action != 'configuration_missing' }}
         uses: ./.github/actions/send-slack-notification
         with:
           channel: APP_DEV_ANALYTICS
@@ -64,6 +64,21 @@ jobs:
           fields: >-
             [{"title":"Instance","value":"${{ steps.resume.outputs.instance_id || env.NEO4J_AURA_INSTANCE_ID }}","short":true},{"title":"Last status","value":"${{ steps.resume.outputs.status || 'unknown' }}","short":true},{"title":"Action","value":"${{ steps.resume.outputs.action || 'failed' }}","short":true}]
 
+      - name: Notify deployment analytics when Aura credentials are missing
+        if: ${{ steps.resume.outcome != 'success' && steps.resume.outputs.action == 'configuration_missing' }}
+        uses: ./.github/actions/send-slack-notification
+        with:
+          channel: APP_DEV_ANALYTICS
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_APP_DEV_ANALYTICS }}
+          workflow_name: Neo4j Aura Resume Guard
+          status: warning
+          verbiage: Aura Resume
+          message: |
+            :warning: *Neo4j Aura resume guard is not configured*
+            Add `NEO4J_AURA_CLIENT_ID` and `NEO4J_AURA_CLIENT_SECRET` repository secrets to let the guard resume paused AuraDB instances.
+          fields: >-
+            [{"title":"Instance","value":"${{ steps.resume.outputs.instance_id || env.NEO4J_AURA_INSTANCE_ID }}","short":true},{"title":"Action","value":"configuration_missing","short":true}]
+
       - name: Fail workflow when resume guard failed
-        if: ${{ steps.resume.outcome != 'success' }}
+        if: ${{ steps.resume.outcome != 'success' && (steps.resume.outputs.action != 'configuration_missing' || github.event_name == 'workflow_dispatch') }}
         run: exit 1

--- a/.github/workflows/observability-production.yml
+++ b/.github/workflows/observability-production.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      skipped_reason: ${{ steps.bootstrap.outputs.skipped_reason }}
     env:
       EC2_HOST: ${{ secrets.EC2_HOST }}
       EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID || vars.EC2_INSTANCE_ID || '' }}
@@ -29,6 +31,7 @@ jobs:
       AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID || '' }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY || '' }}
+      OBSERVABILITY_REQUIRE_EC2_SSH: ${{ vars.OBSERVABILITY_REQUIRE_EC2_SSH || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -72,6 +75,7 @@ jobs:
             monitoring/grafana/datasources
 
       - name: Bootstrap observability stack on EC2
+        id: bootstrap
         run: |
           set -euo pipefail
 
@@ -84,6 +88,12 @@ jobs:
           ssh_opts=(-o StrictHostKeyChecking=no -o LogLevel=ERROR -o BatchMode=yes -o ConnectTimeout=20 -o ConnectionAttempts=2 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes)
 
           if ! ssh "${ssh_opts[@]}" -i "${key_file}" "${EC2_USER}@${EC2_HOST}" "printf 'ssh-ok\n'"; then
+            if [ "${{ github.event_name }}" = "schedule" ] && [ "$(printf '%s' "${OBSERVABILITY_REQUIRE_EC2_SSH}" | tr '[:upper:]' '[:lower:]')" != "true" ]; then
+              echo "::warning::Production EC2 is not reachable over SSH from the GitHub runner. Skipping scheduled observability bootstrap without failing the workflow."
+              echo "skipped_reason=ec2_ssh_unreachable" >> "$GITHUB_OUTPUT"
+              echo "OBSERVABILITY_SKIPPED_REASON=ec2_ssh_unreachable" >> "$GITHUB_ENV"
+              exit 0
+            fi
             echo "::error::Unable to reach production EC2 over SSH. Verify the resolved host, instance state, and security group ingress for GitHub-hosted runners on port 22."
             exit 1
           fi
@@ -499,6 +509,7 @@ jobs:
             echo "| Remote directory | \`${OBSERVABILITY_DIR}\` |"
             echo "| Bundle file | \`docker-compose.observability.yml\` |"
             echo "| Config source | \`~/smart-tutor.env\` on EC2 |"
+            echo "| Skipped reason | \`${OBSERVABILITY_SKIPPED_REASON:-none}\` |"
             echo "| Services | \`prometheus\`, \`grafana\`, \`alertmanager\`, \`postgres-exporter\`, \`redis-exporter\`, \`node-exporter\`, \`cadvisor\` |"
             echo "| Validated HTTP checks | \`9090/-/ready\`, \`3001/api/health\`, \`9093/-/healthy\`, \`9187/metrics\`, \`9121/metrics\`, \`9100/metrics\`, \`8080/metrics\` |"
             echo "| Validated Prometheus jobs | \`prometheus\`, \`backend-api\`, \`postgresql\`, \`redis\`, \`node\`, \`cadvisor\` |"
@@ -521,10 +532,10 @@ jobs:
     with:
       channel: SMART_TUTOR_AI
       workflow_name: Production Observability Bootstrap
-      status: ${{ needs.observability.result == 'failure' && 'failure' || 'success' }}
+      status: ${{ needs.observability.outputs.skipped_reason != '' && 'warning' || (needs.observability.result == 'failure' && 'failure' || 'success') }}
       verbiage: Observability
       message: |
-        ${{ needs.observability.result == 'failure' && ':x: *Observability bootstrap FAILED* — monitoring stack not deployed or backend observability checks failed.' || ':white_check_mark: *Observability bootstrap SUCCEEDED* — Prometheus, Grafana, Alertmanager, exporters, and backend Langfuse/PostHog checks are validated.' }}
+        ${{ needs.observability.outputs.skipped_reason != '' && ':warning: *Observability bootstrap skipped* — production EC2 was not reachable over SSH from the scheduled runner.' || (needs.observability.result == 'failure' && ':x: *Observability bootstrap FAILED* — monitoring stack not deployed or backend observability checks failed.' || ':white_check_mark: *Observability bootstrap SUCCEEDED* — Prometheus, Grafana, Alertmanager, exporters, and backend Langfuse/PostHog checks are validated.') }}
         Trigger: `${{ github.event_name }}`. Scheduled daily at 13:00 UTC.
       fields: >-
         [
@@ -543,10 +554,10 @@ jobs:
     with:
       channel: APP_DEV_ANALYTICS
       workflow_name: Production Observability Bootstrap
-      status: ${{ needs.observability.result == 'failure' && 'failure' || 'success' }}
+      status: ${{ needs.observability.outputs.skipped_reason != '' && 'warning' || (needs.observability.result == 'failure' && 'failure' || 'success') }}
       verbiage: Observability
       message: |
-        ${{ needs.observability.result == 'failure' && ':x: *Observability bootstrap FAILED*' || ':white_check_mark: *Observability bootstrap completed* — monitoring stack and backend observability checks deployed to EC2.' }}
+        ${{ needs.observability.outputs.skipped_reason != '' && ':warning: *Observability bootstrap skipped* — production EC2 was not reachable over SSH from the scheduled runner.' || (needs.observability.result == 'failure' && ':x: *Observability bootstrap FAILED*' || ':white_check_mark: *Observability bootstrap completed* — monitoring stack and backend observability checks deployed to EC2.') }}
         Services: Prometheus, Grafana, Alertmanager, postgres-exporter, redis-exporter, node-exporter, cadvisor. Backend checks: Langfuse, PostHog.
       fields: >-
         [

--- a/.github/workflows/rag-evaluation-scheduled.yml
+++ b/.github/workflows/rag-evaluation-scheduled.yml
@@ -121,6 +121,7 @@ jobs:
           MAX_AVG_DRIFT_SCORE: ${{ inputs.max_avg_drift_score || vars.MAX_AVG_DRIFT_SCORE || '2.50' }}
           EVALUATION_MODEL_ID: ${{ inputs.model_id || vars.EVALUATION_MODEL_ID || '' }}
           ENFORCE_QUALITY_GATES: ${{ inputs.enforce_quality_gates || vars.ENFORCE_QUALITY_GATES || 'false' }}
+          SCHEDULED_RAG_REQUIRE_BACKEND: ${{ vars.SCHEDULED_RAG_REQUIRE_BACKEND || 'false' }}
           INTERNAL_EVALUATION_TIMEOUT_SECONDS: ${{ vars.EVALUATION_INTERNAL_TIMEOUT_SECONDS || '900' }}
           PUBLIC_EVALUATION_TIMEOUT_SECONDS: ${{ vars.EVALUATION_PUBLIC_TIMEOUT_SECONDS || '120' }}
           WORKFLOW_TRIGGER: ${{ github.event_name }}
@@ -397,6 +398,14 @@ jobs:
 
           # ── Fail the step if the backend returned an error ─────────────────
           if [ -z "${http_code}" ] || [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+            if [ "${WORKFLOW_TRIGGER}" = "schedule" ] && \
+               [ "$(printf '%s' "${SCHEDULED_RAG_REQUIRE_BACKEND}" | tr '[:upper:]' '[:lower:]')" != "true" ] && \
+               { [ -z "${http_code}" ] || [ "${http_code}" = "000" ]; }; then
+              echo "::warning::Scheduled RAG evaluation backend is unreachable. Recording warning and leaving the scheduled workflow green."
+              jq '. + {skipped_reason: "backend_unreachable"}' /tmp/eval_summary.json > /tmp/eval_summary.tmp
+              mv /tmp/eval_summary.tmp /tmp/eval_summary.json
+              exit 0
+            fi
             echo "::error::Backend returned HTTP ${http_code:-0}. See response body above for details."
             echo "Response: ${response}"
             exit 1
@@ -496,6 +505,7 @@ jobs:
           quality_gate="PASSED"
           notify_message=":white_check_mark: *RAG evaluation completed*"
           failure_detail=""
+          skipped_reason=""
           http_code="unknown"
           response_source="unknown"
           avg_correctness="unknown"
@@ -506,6 +516,7 @@ jobs:
 
           if [ -f /tmp/eval_summary.json ]; then
             http_code="$(jq -r '.http_code // "unknown"' /tmp/eval_summary.json 2>/dev/null || echo "unknown")"
+            skipped_reason="$(jq -r '.skipped_reason // empty' /tmp/eval_summary.json 2>/dev/null || true)"
             response_source="$(jq -r '.response_source // "unknown"' /tmp/eval_summary.json 2>/dev/null || echo "unknown")"
             avg_c="$(jq -r '.response.quality_summary.avg_correctness // empty' /tmp/eval_summary.json 2>/dev/null || true)"
             avg_correctness="$(jq -r '.response.quality_summary.avg_correctness // "unknown"' /tmp/eval_summary.json 2>/dev/null || echo "unknown")"
@@ -514,7 +525,13 @@ jobs:
             total_evaluated="$(jq -r '.response.total_evaluated // "unknown"' /tmp/eval_summary.json 2>/dev/null || echo "unknown")"
           fi
 
-          if [ "${eval_result}" = "failure" ]; then
+          if [ -n "${skipped_reason}" ]; then
+            overall_status="warning"
+            quality_gate="SKIPPED"
+            printf -v notify_message ':warning: *RAG evaluation skipped*\nReason: `%s`. Quality gate: *%s*' \
+              "${skipped_reason}" \
+              "${quality_gate}"
+          elif [ "${eval_result}" = "failure" ]; then
             overall_status="failure"
             quality_gate="FAILED"
             if [ "${http_code}" != "unknown" ]; then


### PR DESCRIPTION
## Summary
- Keep Production Deploy strict but restore dynamic EC2 resolution, auto-start, temporary SSH ingress, and cleanup for backend deploy SSH.
- Treat scheduled EC2 observability/compliance SSH reachability as a warning/skip instead of a permanent red workflow, while manual dispatches remain strict.
- Treat scheduled RAG backend HTTP 000/unreachable cases as a warning/skip, while real backend HTTP errors and manual dispatches remain strict.
- Expand Neo4j Aura credential aliases and stop scheduled runs from failing when Aura API credentials are not configured; manual dispatch still fails fast.

## Root causes from latest logs
- Neo4j Aura Resume Guard: `NEO4J_AURA_CLIENT_ID` and `NEO4J_AURA_CLIENT_SECRET` were empty.
- Production Observability Bootstrap / Production Compliance Scan: EC2 resolved and temporary ingress was attempted, but SSH to port 22 timed out before remote commands ran.
- Scheduled RAG Evaluation: public backend calls timed out and EC2 fallback also could not SSH to the host.
- Production Deploy on main still used static `EC2_HOST` in the transfer/deploy path.

## Validation
- Ruby YAML parse for all `.github/workflows/*.yml`
- `bash -n scripts/ci/resolve_ec2_target.sh scripts/ci/revoke_ec2_ssh_ingress.sh`
- `python3 -m py_compile scripts/resume_neo4j_aura.py`
- `git diff --check`

Note: Docker is not running locally, so Docker-based `actionlint` could not be executed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Workflow Resilience**
  * Compliance checks, observability monitoring, and evaluation workflows now gracefully skip runs when infrastructure becomes temporarily unreachable instead of failing
  * Enhanced Slack notifications to report skipped runs and their reasons

* **Deployment Security**
  * Production deployments now automatically revoke temporary access credentials after completion

* **Workflow Configuration**
  * New optional flags to control whether workflows fail or skip when external dependencies are unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liteshperumalla/Smart-Tutor-AI-AI-Driven-Personalized-Teaching-Support/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->