### PR TITLE
feat(frontend): unify pages under shared Claude Design Language hero

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { PageShell } from "@/components/page-shell";
+import { PageHero } from "@/components/page-hero";
+import { Info } from "lucide-react";
 
 const keyFeatures = [
   {
@@ -41,6 +43,12 @@ const developerLinks = [
 export default function AboutPage() {
   return (
     <PageShell className="max-w-5xl" contentClassName="gap-10" noCard>
+        <PageHero
+          icon={Info}
+          title="About"
+          accent="Smart AI Tutor"
+          subtitle="A grounded, citation-first study companion for INFO 5731 — built to teach, quiz, and guide without the hallucinations."
+        />
         <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 animate-fade-in-up">
            <div className="flex items-center gap-3 mb-4">
              <h2 className="text-xl font-semibold text-zinc-900 dark:text-white">Purpose</h2>

--- a/frontend/src/app/appointments/page.tsx
+++ b/frontend/src/app/appointments/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { createAppointment, fetchAppointments, AppointmentRecord } from "@/lib/api";
 import { useAuthToken } from "@/hooks/useAuthToken";
 import { Calendar, User, Mail, Clock, MessageSquare, Send, CheckCircle, CalendarDays, Users, FileText } from "lucide-react";
+import { PageHero } from "@/components/page-hero";
 import { toast } from "sonner";
 
 const REASONS = [
@@ -78,15 +79,12 @@ export default function AppointmentsPage() {
   return (
     <div className="max-w-5xl mx-auto px-4 py-8 animate-fade-in-up">
       {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-center gap-3 mb-2">
-          <div className="p-2.5 rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white">
-            <CalendarDays className="h-6 w-6" />
-          </div>
-          <h1 className="text-3xl font-bold text-zinc-900 dark:text-white">Appointments</h1>
-        </div>
-        <p className="text-zinc-500 dark:text-zinc-400 ml-14">Schedule meetings with professors and teaching assistants</p>
-      </div>
+      <PageHero
+        className="mb-8"
+        icon={CalendarDays}
+        title="Appointments"
+        subtitle="Schedule meetings with professors and teaching assistants."
+      />
 
       <div className="grid gap-8 lg:grid-cols-5">
         {/* Request Form */}

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -24,7 +24,7 @@ import { PageShell } from "@/components/page-shell";
 import {
   MessageCircle, User, Bot, Send, Trash2, Mic, MicOff, Plus, X, Check, ChevronDown,
   Globe, Paperclip, ChevronRight, Image, FileText, FlaskConical, ShieldAlert,
-  Sparkles, BookOpen, Code2, Lightbulb, Activity, GitCompare, Gauge, ShieldCheck
+  ShieldCheck
 } from "lucide-react";
 import { useUser } from "@/hooks/useUser";
 import { useFeatureFlag } from "@/hooks/useFeatureFlag";
@@ -1667,50 +1667,6 @@ function ChatWorkspaceContent() {
             </p>
           </div>
 
-          {/* Suggested prompts - only show when no messages */}
-          {isLoggedIn && (!activeSession || !hasMessages) && (
-            <div className="mx-auto mt-6 grid w-full max-w-xl grid-cols-1 gap-2.5 text-left sm:grid-cols-2">
-              {(isAdmin
-                ? [
-                    { Icon: Activity, label: "Run a system health check on the RAG pipeline", hint: "Diagnostics" },
-                    { Icon: GitCompare, label: "Test multi-model response comparison for a complex query", hint: "Models" },
-                    { Icon: Gauge, label: "What are the current system metrics and performance stats?", hint: "Metrics" },
-                    { Icon: ShieldCheck, label: "Evaluate the quality of responses for edge-case queries", hint: "Evaluation" },
-                  ]
-                : [
-                    { Icon: Sparkles, label: "Explain TF-IDF using the Module 3 reading", hint: "Module 3" },
-                    { Icon: BookOpen, label: "Summarize Lecture 8 in three bullet points", hint: "Lecture 8" },
-                    { Icon: Code2, label: "Walk me through the embeddings code demo", hint: "Code · Module 4" },
-                    { Icon: Lightbulb, label: "Quiz me on RAG vs fine-tuning", hint: "Practice" },
-                  ]
-              ).map(({ Icon: SuggestionIcon, label, hint }) => {
-                const accent = isAdmin
-                  ? "hover:border-amber-500 hover:bg-amber-500/[0.05] dark:hover:border-amber-500"
-                  : "hover:border-emerald-500 hover:bg-emerald-500/[0.04] dark:hover:border-emerald-500";
-                const tile = isAdmin
-                  ? "bg-amber-500/10 text-amber-700 dark:text-amber-300"
-                  : "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
-                return (
-                  <button
-                    key={label}
-                    type="button"
-                    onClick={() => setComposerText(label)}
-                    className={`flex items-start gap-2.5 rounded-2xl border border-zinc-200 bg-white p-3 text-left text-[13px] font-medium text-zinc-800 transition dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 ${accent}`}
-                  >
-                    <span className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg ${tile}`}>
-                      <SuggestionIcon className="h-3.5 w-3.5" />
-                    </span>
-                    <span className="flex-1 leading-snug">
-                      {label}
-                      <span className="mt-1 block font-mono text-[10.5px] tracking-wide text-zinc-400 dark:text-zinc-500">
-                        {hint}
-                      </span>
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
       </div>
 
       {/* File Viewer Modal */}

--- a/frontend/src/app/feedback/page.tsx
+++ b/frontend/src/app/feedback/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { postJSON } from "@/lib/api";
 import { useAuthToken } from "@/hooks/useAuthToken";
 import { MessageSquare, Bug, User, Mail, Tag, FileText, Send, CheckCircle, AlertTriangle, Sparkles, ThumbsUp, Zap, ShieldAlert } from "lucide-react";
+import { PageHero } from "@/components/page-hero";
 import { useUser } from "@/hooks/useUser";
 import { toast } from "sonner";
 
@@ -83,13 +84,13 @@ export default function FeedbackPage() {
   return (
     <div className="max-w-3xl mx-auto px-4 py-8 animate-fade-in-up">
       {/* Header */}
-      <div className="text-center mb-8">
-        <div className="inline-flex items-center justify-center p-3 rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-600 text-white mb-4">
-          <MessageSquare className="h-8 w-8" />
-        </div>
-        <h1 className="text-3xl font-bold text-zinc-900 dark:text-white mb-2">Feedback & Support</h1>
-        <p className="text-zinc-500 dark:text-zinc-400">Help us improve by sharing your thoughts or reporting issues</p>
-      </div>
+      <PageHero
+        className="mb-8"
+        icon={MessageSquare}
+        title="Feedback &"
+        accent="Support"
+        subtitle="Help us improve by sharing your thoughts or reporting issues."
+      />
 
       {/* Admin Notice */}
       {isAdmin && (

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,6 +1,14 @@
 @import "tailwindcss";
 @import url('https://api.fontshare.com/v2/css?f[]=clash-display@600,700&f[]=cabinet-grotesk@400,500,700&display=swap');
 
+/* Tailwind v4 defaults the `dark:` variant to the `prefers-color-scheme`
+   media query. This app toggles theme explicitly via a `.dark` class on
+   <html> (see theme-context.tsx), so we override the variant to key off
+   that class. Without this, clicking "Switch to Light" on an OS that is in
+   dark mode leaves every `dark:` utility firing off the OS preference,
+   producing a half-broken light theme. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   /* Typography */
   --font-display: 'Clash Display', 'Space Grotesk', sans-serif;
@@ -34,19 +42,23 @@
   --color-success: #059669;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-primary: #10b981;      /* Brighter Emerald - vibrant for dark mode */
-    --color-secondary: #6366f1;    /* Brighter Indigo - better contrast */
-    --color-accent: #fbbf24;       /* Lighter Amber - energetic in dark */
-    --color-achieve: #fbbf24;      /* Lighter Amber - achievements (alias) */
-    --color-highlight: #fb7185;    /* Lighter Rose - highlights in dark */
-    --color-bright: #34d399;       /* Brighter Emerald - pops on dark background */
-    --color-success: #10b981;      /* Matches primary */
-    --color-subtle: #c4b5fd;       /* Lighter Lavender - visible on dark */
-    --background: #0f172a;   /* Slate Foundation - sophisticated dark */
-    --foreground: #f8fafc;   /* Cloud White - crisp text */
-  }
+/* Dark-mode color tokens. Gated on the `.dark`/`.theme-dark` class (set by
+   theme-context.tsx) rather than `@media (prefers-color-scheme: dark)`, so an
+   explicit "Switch to Light" choice always wins even when the OS is dark.
+   First-load OS preference is still honored: theme-context reads
+   prefers-color-scheme on mount and applies the class when no choice is stored. */
+.dark,
+.theme-dark {
+  --color-primary: #10b981;      /* Brighter Emerald - vibrant for dark mode */
+  --color-secondary: #6366f1;    /* Brighter Indigo - better contrast */
+  --color-accent: #fbbf24;       /* Lighter Amber - energetic in dark */
+  --color-achieve: #fbbf24;      /* Lighter Amber - achievements (alias) */
+  --color-highlight: #fb7185;    /* Lighter Rose - highlights in dark */
+  --color-bright: #34d399;       /* Brighter Emerald - pops on dark background */
+  --color-success: #10b981;      /* Matches primary */
+  --color-subtle: #c4b5fd;       /* Lighter Lavender - visible on dark */
+  --background: #0f172a;   /* Slate Foundation - sophisticated dark */
+  --foreground: #f8fafc;   /* Cloud White - crisp text */
 }
 
 body {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -44,8 +44,16 @@ export default function RootLayout({
   ];
 
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        {/* Pre-paint theme: set the .dark/.theme-dark class before first paint so
+            an OS-dark or previously-chosen-dark user doesn't flash a light screen.
+            Mirrors theme-context.tsx (same storage key + initial logic). */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var k="smart-ai-tutor-theme",s=localStorage.getItem(k);var d=s==="dark"||(s!=="light"&&window.matchMedia("(prefers-color-scheme: dark)").matches);if(d){document.documentElement.classList.add("dark","theme-dark");}}catch(e){}})();`,
+          }}
+        />
         <PostHogProvider>
           <ErrorBoundary>
             <ThemeProvider>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -99,7 +99,7 @@ export default async function Home() {
             <h2 className="font-display text-2xl font-bold mb-6">Quick Actions</h2>
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               {quickActions.map((action, i) => {
-                const featured = action.href === "/code";
+                const featured = action.href === "/code" || action.href === "/chat";
                 return (
                   <Link
                     key={action.title}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -21,6 +21,7 @@ import {
 import { useAuthToken } from "@/hooks/useAuthToken";
 import { useTheme } from "@/context/theme-context";
 import { PageShell } from "@/components/page-shell";
+import { PageHero } from "@/components/page-hero";
 import {
   User, Camera, Mail, Phone, Calendar, Trophy, Clock,
   MessageSquare, Bug, Save, Lock, Shield, Trash2, StickyNote, ShieldAlert, BarChart3, Users, Settings
@@ -329,16 +330,12 @@ export default function ProfilePage() {
 
   return (
     <PageShell className="max-w-5xl" contentClassName="gap-8" noCard>
-      <header className="relative overflow-hidden rounded-3xl p-6 sm:p-8 lg:p-12 animate-fade-in-down">
-        <div className="relative z-10">
-          <h1 className="font-display text-3xl sm:text-5xl font-bold text-zinc-900 dark:text-white">
-            Manage your account
-          </h1>
-          <p className="mt-3 text-base sm:mt-4 sm:text-lg text-zinc-600 max-w-2xl dark:text-zinc-400">
-            Update your profile, track your progress, and manage your settings
-          </p>
-        </div>
-      </header>
+      <PageHero
+        icon={User}
+        title="Manage your"
+        accent="account"
+        subtitle="Update your profile, track your progress, and manage your settings."
+      />
 
       {profile.user.role === "Admin" && (
         <section className="rounded-2xl border border-amber-200 bg-amber-50/50 p-6 shadow-sm dark:border-amber-800/50 dark:bg-amber-950/20">

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/api";
 import { useAuthToken } from "@/hooks/useAuthToken";
 import { Brain, History, Trophy, CheckCircle, XCircle, Folder, Sparkles, Target, Clock, Award, Lightbulb } from "lucide-react";
+import { PageHero } from "@/components/page-hero";
 import { toast } from "sonner";
 
 export default function QuizPage() {
@@ -184,15 +185,13 @@ export default function QuizPage() {
   return (
     <div className="max-w-6xl mx-auto px-4 py-8 animate-fade-in-up">
       {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-center gap-3 mb-2">
-          <div className="p-2.5 rounded-xl bg-gradient-to-br from-purple-500 to-indigo-600 text-white">
-            <Brain className="h-6 w-6" />
-          </div>
-          <h1 className="text-3xl font-bold text-zinc-900 dark:text-white">Knowledge Quiz</h1>
-        </div>
-        <p className="text-zinc-500 dark:text-zinc-400 ml-14">Test your understanding of course materials</p>
-      </div>
+      <PageHero
+        className="mb-8"
+        icon={Brain}
+        title="Knowledge"
+        accent="Quiz"
+        subtitle="Test your understanding of course materials."
+      />
 
       <div className="grid gap-6 lg:grid-cols-4">
         {/* Quiz Setup */}

--- a/frontend/src/app/resources/page.tsx
+++ b/frontend/src/app/resources/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { fetchResources, fetchResearchUploads, getResourceDownloadUrl, ResearchUpload, Resource } from "@/lib/api";
 import { useAuthToken } from "@/hooks/useAuthToken";
 import { PageShell } from "@/components/page-shell";
+import { PageHero } from "@/components/page-hero";
 import { FolderOpen, ExternalLink, FileText, Download } from "lucide-react";
 
 type CategoryMap = Record<string, { title: string; url: string }[]>;
@@ -69,6 +70,12 @@ export default function ResourcesPage() {
 
   return (
     <PageShell className="max-w-5xl" contentClassName="gap-8" noCard>
+      <PageHero
+        icon={FolderOpen}
+        title="Resource"
+        accent="Hub"
+        subtitle="Lecture slides, Canvas links, readings, and uploaded files — curated for INFO 5731 in one place."
+      />
       {error && (
         <p className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-400">
           {error}

--- a/frontend/src/components/page-hero.tsx
+++ b/frontend/src/components/page-hero.tsx
@@ -1,0 +1,99 @@
+import { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+
+interface PageHeroProps {
+  /** Leading text of the title (rendered in the foreground color). */
+  title: ReactNode;
+  /** Optional trailing word rendered with the green→indigo gradient accent. */
+  accent?: ReactNode;
+  /** Supporting copy under the title. */
+  subtitle?: ReactNode;
+  /** Optional Lucide icon shown as a chip above the title. */
+  icon?: LucideIcon;
+  /** Extra classes for the outer header element. */
+  className?: string;
+  /** Optional right-aligned slot (e.g. action buttons). */
+  actions?: ReactNode;
+}
+
+/**
+ * Shared "Claude Design Language" page hero: a rounded gradient banner with a
+ * dotted texture, two blurred decorative blobs, and a font-display title whose
+ * accent word picks up the green→indigo brand gradient. Mirrors the home page
+ * header so every page shares one consistent header treatment.
+ */
+export function PageHero({
+  title,
+  accent,
+  subtitle,
+  icon: Icon,
+  className,
+  actions,
+}: PageHeroProps) {
+  const outerClassName = [
+    "relative overflow-hidden rounded-3xl border border-zinc-200 p-6 sm:p-8 lg:p-10",
+    "animate-fade-in-down dark:border-zinc-800",
+    "bg-[linear-gradient(160deg,#ecfdf5_0%,#ffffff_55%,#eef2ff_100%)]",
+    "dark:bg-[linear-gradient(160deg,#04201d_0%,#0f172a_55%,#1a193f_100%)]",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <header className={outerClassName}>
+      {/* Dotted texture */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-40 dark:opacity-20"
+        style={{
+          backgroundImage:
+            "radial-gradient(rgba(15,23,42,0.06) 1px, transparent 1px)",
+          backgroundSize: "22px 22px",
+        }}
+      />
+      {/* Decorative blobs */}
+      <div
+        className="pointer-events-none absolute -top-20 -right-16 h-60 w-60 rounded-full blur-3xl animate-float"
+        style={{ background: "rgba(16,185,129,0.18)" }}
+      />
+      <div
+        className="pointer-events-none absolute -bottom-20 -left-10 h-52 w-52 rounded-full blur-3xl"
+        style={{ background: "rgba(99,102,241,0.16)", animationDelay: "1s" }}
+      />
+
+      <div className="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          {Icon && (
+            <span className="mb-4 inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/70 text-emerald-600 shadow-sm ring-1 ring-zinc-200 dark:bg-white/10 dark:text-emerald-400 dark:ring-white/10">
+              <Icon className="h-5 w-5" />
+            </span>
+          )}
+          <h1 className="font-display text-3xl font-bold leading-[1.05] tracking-tight text-zinc-900 dark:text-white sm:text-4xl lg:text-5xl">
+            {title}
+            {accent != null && (
+              <>
+                {" "}
+                <span
+                  style={{
+                    backgroundImage: "linear-gradient(90deg, #059669, #4f46e5)",
+                    WebkitBackgroundClip: "text",
+                    backgroundClip: "text",
+                    color: "transparent",
+                  }}
+                >
+                  {accent}
+                </span>
+              </>
+            )}
+          </h1>
+          {subtitle && (
+            <p className="mt-3 max-w-2xl text-base leading-relaxed text-zinc-600 dark:text-zinc-300 sm:text-lg">
+              {subtitle}
+            </p>
+          )}
+        </div>
+        {actions && <div className="relative z-10 flex-shrink-0">{actions}</div>}
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
Brings every primary page under one consistent **Claude Design Language** header, plus the prior UI-polish round.

### Shared hero
- New `frontend/src/components/page-hero.tsx` — a reusable `PageHero`: rounded gradient banner (light + `dark:` variants) + dotted texture + two blurred decorative blobs + `font-display` title with a green→indigo gradient-accent word + optional Lucide icon chip + subtitle. Mirrors the home page header.
- Applied to **Quiz, Appointments, Resources, About, Feedback, Profile**, replacing each page's ad-hoc icon pill / plain `text-3xl` title.

### Prior UI round (also in this branch)
- **Home:** "Start chatting" Quick Action now uses the Code-sandbox green→indigo gradient.
- **Dark/Light mode fix:** rebind Tailwind v4 `dark:` variant to the `.dark` class via `@custom-variant`, gate dark color tokens on `.dark`/`.theme-dark` (was `prefers-color-scheme`), and add a no-flash pre-paint theme script in the root layout. Fixes light mode being inoperative on OS-dark machines.
- **Chat:** remove the bottom starter-prompt suggestion cards from the welcome screen.

## Verification
- `tsc --noEmit` clean; ESLint 0 errors.
- Frontend + backend rebuilt in Docker; both containers healthy.
- All routes (`/`, `/quiz`, `/appointments`, `/resources`, `/about`, `/feedback`, `/profile`) return HTTP 200; hero gradient banner confirmed in served HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Redesigned page headers across About, Appointments, Feedback, Profile, Quiz, and Resources sections.
  * Removed suggested prompts from the empty chat state.

* **Home Page**
  * Featured both Code and Chat quick actions.

* **Dark Mode**
  * Improved theme initialization for better dark mode support and switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->