### PR TITLE
feat(frontend): quiz gradient, true-black dark mode, About + Resources redesign

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -2,145 +2,170 @@
 
 import { PageShell } from "@/components/page-shell";
 import { PageHero } from "@/components/page-hero";
-import { Info } from "lucide-react";
+import {
+  Info,
+  LayoutGrid,
+  Layers,
+  User,
+  MessageSquare,
+  Brain,
+  Sparkles,
+  FolderOpen,
+  CalendarDays,
+  ShieldCheck,
+  Github,
+  Linkedin,
+  Mail,
+  type LucideIcon,
+} from "lucide-react";
 
-const keyFeatures = [
+const keyFeatures: { icon: LucideIcon; title: string; body: string }[] = [
   {
-    title: "Interactive Document Chat",
-    body: "Ask contextual questions about your uploaded materials and get cited responses.",
+    icon: MessageSquare,
+    title: "Interactive document chat",
+    body: "Ask contextual questions about uploaded materials and get cited responses.",
   },
   {
-    title: "Custom Quiz Generation",
+    icon: Brain,
+    title: "Custom quiz generation",
     body: "Create formative assessments sourced directly from class content.",
   },
   {
-    title: "Personalized Tutoring",
+    icon: Sparkles,
+    title: "Personalized tutoring",
     body: "Receive AI guidance that adapts to your progress and pace.",
   },
   {
-    title: "Resource Hub",
+    icon: FolderOpen,
+    title: "Resource hub",
     body: "Browse a curated library of INFO 5731 readings, slides, and notes.",
   },
   {
-    title: "Appointment Scheduling",
+    icon: CalendarDays,
+    title: "Appointment scheduling",
     body: "Book meetings with professors or TAs without leaving the tutor.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Grounded answers",
+    body: "Every response cites a real chunk of indexed course material.",
   },
 ];
 
 const techStack = [
-  { label: "Frontend", value: "Next.js & TailwindCSS" },
-  { label: "Backend & AI Core", value: "FastAPI, Python, LlamaIndex" },
-  { label: "LLM Runtime", value: "AWS Bedrock (Llama 3.1 70B)" },
-  { label: "File Processing", value: "PyMuPDF, python-pptx, docx" },
+  { label: "Frontend", value: "Next.js · React 19 · Tailwind v4" },
+  { label: "Backend & AI", value: "FastAPI · Python · LlamaIndex" },
+  { label: "LLM Runtime", value: "AWS Bedrock · Llama 3.1 70B" },
+  { label: "File Processing", value: "PyMuPDF · python-pptx · docx" },
 ];
 
-const developerLinks = [
-  { label: "Email", href: "mailto:liteshperumalla@my.unt.edu" },
-  { label: "GitHub", href: "https://github.com/liteshperumalla" },
-  { label: "LinkedIn", href: "https://www.linkedin.com/in/perumalla-litesh/" },
+const developerLinks: { icon: LucideIcon; label: string; href: string }[] = [
+  { icon: Github, label: "GitHub", href: "https://github.com/liteshperumalla" },
+  { icon: Linkedin, label: "LinkedIn", href: "https://www.linkedin.com/in/perumalla-litesh/" },
+  { icon: Mail, label: "Email", href: "mailto:liteshperumalla@my.unt.edu" },
 ];
+
+function SectionLabel({ icon: Icon, children }: { icon: LucideIcon; children: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500 dark:text-zinc-400">
+      <Icon className="h-4 w-4" />
+      {children}
+    </div>
+  );
+}
 
 export default function AboutPage() {
   return (
     <PageShell className="max-w-5xl" contentClassName="gap-10" noCard>
-        <PageHero
-          icon={Info}
-          title="About"
-          accent="Smart AI Tutor"
-          subtitle="A grounded, citation-first study companion for INFO 5731 — built to teach, quiz, and guide without the hallucinations."
-        />
-        <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 animate-fade-in-up">
-           <div className="flex items-center gap-3 mb-4">
-             <h2 className="text-xl font-semibold text-zinc-900 dark:text-white">Purpose</h2>
-           </div>
-          <p className="mt-3 text-sm text-zinc-600 dark:text-zinc-400">
-            Smart AI Tutor is designed to help students engage with course artifacts, test their
-            understanding, and collaborate with AI in a trustworthy way. By grounding every answer in
-            the indexed corpus, the tutor reduces hallucinations while surfacing the most relevant
-            knowledge from INFO 5731.
-          </p>
-          <div className="mt-6 grid gap-3 md:grid-cols-2">
-            {keyFeatures.map((feature, i) => (
+      <PageHero
+        icon={Info}
+        eyebrow="About"
+        title="Why Smart"
+        accent="AI Tutor exists."
+        subtitle="An RAG-grounded tutor for INFO 5731. Built so students always get answers backed by the actual lectures and readings."
+      />
+
+      {/* Key features */}
+      <section className="animate-fade-in-up">
+        <SectionLabel icon={LayoutGrid}>Key Features</SectionLabel>
+        <div className="mt-5 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {keyFeatures.map((feature, i) => {
+            const Icon = feature.icon;
+            return (
               <article
                 key={feature.title}
-                className="group rounded-2xl border border-zinc-100 bg-zinc-50/80 p-4 transition hover:-translate-y-1 hover:border-indigo-200 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-800/50 dark:hover:border-indigo-800"
-                style={{animationDelay: `${i * 0.1}s`}}
+                className="group rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900"
+                style={{ animationDelay: `${i * 0.05}s` }}
               >
-                 <div className="mb-3">
-                  <h3 className="text-base font-semibold text-zinc-900 dark:text-white">{feature.title}</h3>
-                </div>
-                <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">{feature.body}</p>
+                <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400">
+                  <Icon className="h-5 w-5" />
+                </span>
+                <h3 className="font-display mt-5 text-lg font-bold text-zinc-900 dark:text-white">
+                  {feature.title}
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+                  {feature.body}
+                </p>
               </article>
-            ))}
-          </div>
-        </section>
+            );
+          })}
+        </div>
+      </section>
 
-        <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 animate-fade-in-up stagger-1">
-           <div className="flex items-center gap-3 mb-4">
-             <h2 className="text-xl font-semibold text-zinc-900 dark:text-white">Technology Stack</h2>
-           </div>
-          <div className="mt-4 grid gap-4 sm:grid-cols-2">
-            {techStack.map((item) => (
-              <div
-                key={item.label}
-                className="rounded-2xl border border-zinc-100 bg-zinc-50 p-4 text-sm text-zinc-700 dark:border-zinc-800 dark:bg-zinc-800/50 dark:text-zinc-300"
-              >
-                <p className="text-xs uppercase tracking-[0.3em] text-zinc-500 dark:text-zinc-400">{item.label}</p>
-                <p className="pt-2 text-base font-medium text-zinc-900 dark:text-white">{item.value}</p>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 animate-fade-in-up stagger-2">
-           <div className="flex items-center gap-3 mb-4">
-             <h2 className="text-xl font-semibold text-zinc-900 dark:text-white">Developer</h2>
-           </div>
-          <div className="mt-4 flex flex-col gap-6 md:flex-row">
-            <div className="flex-shrink-0">
-              <img
-                src="https://github.com/liteshperumalla.png"
-                alt="Litesh Perumalla"
-                className="h-36 w-36 rounded-full border-4 border-blue-100 object-cover dark:border-blue-900"
-              />
-            </div>
-            <div className="space-y-3 text-sm text-zinc-600 dark:text-zinc-400">
-              <p className="text-lg font-semibold text-zinc-900 dark:text-white">Litesh Perumalla</p>
-              <p>Master&apos;s Student in Data Science, University of North Texas</p>
-              <p>
-                Litesh focuses on AI-first experiences that unlock new ways of learning. His
-                interests include Retrieval-Augmented Generation, human-in-the-loop AI, and
-                full-stack experimentation with Python, FastAPI, and modern JavaScript frameworks.
+      {/* Technology stack */}
+      <section className="animate-fade-in-up stagger-1">
+        <SectionLabel icon={Layers}>Technology Stack</SectionLabel>
+        <div className="mt-5 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+          {techStack.map((item) => (
+            <div
+              key={item.label}
+              className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.25em] text-zinc-400 dark:text-zinc-500">
+                {item.label}
               </p>
-              <div className="flex flex-wrap gap-2">
-                {developerLinks.map((link) => (
-                  <a
-                    key={link.href}
-                    href={link.href}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="rounded-full border border-zinc-200 px-4 py-2 text-xs font-medium text-zinc-700 transition hover:border-zinc-300 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-600"
-                  >
-                    {link.label}
-                  </a>
-                ))}
-              </div>
+              <p className="mt-2 text-sm font-semibold text-zinc-900 dark:text-white">
+                {item.value}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Developer */}
+      <section className="animate-fade-in-up stagger-2 rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 sm:p-8">
+        <SectionLabel icon={User}>Developer</SectionLabel>
+        <div className="mt-6 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-4">
+            <span className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-violet-500 to-indigo-600 text-2xl font-bold text-white">
+              L
+            </span>
+            <div>
+              <p className="font-display text-xl font-bold text-zinc-900 dark:text-white">
+                Litesh Perumalla
+              </p>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">UNT · Computer Science</p>
             </div>
           </div>
-        </section>
-
-        <section className="rounded-3xl border-2 border-blue-200 bg-blue-50/60 p-8 text-center dark:border-blue-800 dark:bg-blue-900/20 animate-fade-in-up stagger-3">
-          <div className="flex items-center justify-center gap-3 mb-4">
-            <h2 className="text-xl font-semibold text-zinc-900 dark:text-white">Contact & Contributions</h2>
+          <div className="flex flex-wrap gap-2.5">
+            {developerLinks.map((link) => {
+              const Icon = link.icon;
+              return (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-2 rounded-full border border-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 transition hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-200 dark:hover:border-zinc-600 dark:hover:bg-zinc-800"
+                >
+                  <Icon className="h-4 w-4" />
+                  {link.label}
+                </a>
+              );
+            })}
           </div>
-          <p className="mt-3 text-sm text-zinc-600 dark:text-zinc-400">
-            Feedback fuels the roadmap. Share feature ideas, report bugs, or contribute evaluations
-            directly from the Feedback page in the tutor sidebar.
-          </p>
-          <div className="mt-4 text-xs uppercase tracking-[0.35em] text-blue-500 dark:text-blue-400">
-            Thank you for supporting smart learning
-          </div>
-        </section>
+        </div>
+      </section>
     </PageShell>
   );
 }

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1269,11 +1269,7 @@ function ChatWorkspaceContent() {
         {/* Welcome screen when no messages */}
         {isLoggedIn && (!activeSession || !hasMessages) && (
           <div className="flex flex-col items-center justify-center flex-1 px-6 text-center pb-16 pt-24">
-            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/25 bg-emerald-500/10 px-3 py-1.5 text-[10.5px] font-semibold uppercase tracking-[0.2em] text-emerald-700 dark:text-emerald-300">
-              <span className="h-[5px] w-[5px] rounded-full bg-emerald-500" style={{ boxShadow: "0 0 6px #10b981" }}></span>
-              Grounded in INFO 5731 corpus
-            </span>
-            <h1 className="font-display mt-4 text-3xl sm:text-4xl font-bold tracking-tight text-zinc-900 dark:text-white mb-3">
+            <h1 className="font-display text-3xl sm:text-4xl font-bold tracking-tight text-zinc-900 dark:text-white mb-3">
               {`Hi, ${getFriendlyUserName(user)}`}
             </h1>
             <p className="text-base sm:text-xl text-zinc-500 dark:text-zinc-400">

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -57,7 +57,7 @@
   --color-bright: #34d399;       /* Brighter Emerald - pops on dark background */
   --color-success: #10b981;      /* Matches primary */
   --color-subtle: #c4b5fd;       /* Lighter Lavender - visible on dark */
-  --background: #0f172a;   /* Slate Foundation - sophisticated dark */
+  --background: #000000;   /* True Black - OLED dark */
   --foreground: #f8fafc;   /* Cloud White - crisp text */
 }
 
@@ -84,20 +84,20 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 700;
 }
 
-/* Dark theme overrides */
+/* Dark theme overrides — neutral near-black palette ("truly black" dark mode) */
 .theme-dark body {
-  background: #0F172A;
+  background: #000000;
   color: #F8FAFC;
 }
 
 body.theme-dark {
-  background: #0F172A;
+  background: #000000;
   color: #F8FAFC;
 }
 
 .theme-dark .bg-zinc-50,
 body.theme-dark .bg-zinc-50 {
-  background-color: #0F172A !important;
+  background-color: #0a0a0a !important;
   color: #F8FAFC;
 }
 
@@ -105,7 +105,7 @@ body.theme-dark .bg-zinc-50 {
 body.theme-dark .bg-white,
 .theme-dark .bg-white\/90,
 body.theme-dark .bg-white\/90 {
-  background-color: rgba(30, 41, 59, 0.9) !important;
+  background-color: #141414 !important;
   color: #F8FAFC;
 }
 
@@ -116,22 +116,22 @@ body.theme-dark .text-zinc-900 {
 
 .theme-dark .text-zinc-600,
 body.theme-dark .text-zinc-600 {
-  color: #CBD5E1 !important;
+  color: #d4d4d4 !important;
 }
 
 .theme-dark .border-zinc-200,
 body.theme-dark .border-zinc-200 {
-  border-color: #475569 !important;
+  border-color: #262626 !important;
 }
 
 .theme-dark .text-zinc-500,
 body.theme-dark .text-zinc-500 {
-  color: #94A3B8 !important;
+  color: #a3a3a3 !important;
 }
 
 .theme-dark .text-zinc-700,
 body.theme-dark .text-zinc-700 {
-  color: #E2E8F0 !important;
+  color: #e5e5e5 !important;
 }
 
 .theme-dark .text-zinc-950,
@@ -159,9 +159,9 @@ body.theme-dark .text-zinc-950 {
 
 .theme-dark .input,
 body.theme-dark .input {
-  background-color: rgba(30, 41, 59, 0.85);
+  background-color: #141414;
   color: #F8FAFC;
-  border-color: #475569;
+  border-color: #262626;
 }
 
 .theme-dark .input:focus,
@@ -219,7 +219,7 @@ body.theme-dark .btn-secondary {
 .theme-dark .btn-secondary:hover,
 body.theme-dark .btn-secondary:hover {
   background-color: #F8FAFC;
-  color: #0F172A;
+  color: #000000;
 }
 
 .btn-ghost {
@@ -259,8 +259,8 @@ body.theme-dark .btn-ghost:hover {
 
 .theme-dark .card,
 body.theme-dark .card {
-  border-color: #475569;
-  background-color: rgba(30, 41, 59, 0.9);
+  border-color: #262626;
+  background-color: #141414;
 }
 
 .card-hover {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -71,7 +71,7 @@ export default async function Home() {
   const professor = overview?.professor;
   return (
     <PageShell contentClassName="gap-10 pb-6" noCard>
-        <header className="relative overflow-hidden rounded-3xl border border-zinc-200 p-6 sm:p-8 lg:p-10 animate-fade-in-down dark:border-zinc-800 bg-[linear-gradient(160deg,#ecfdf5_0%,#ffffff_55%,#eef2ff_100%)] dark:bg-[linear-gradient(160deg,#04201d_0%,#0f172a_55%,#1a193f_100%)]">
+        <header className="relative overflow-hidden rounded-3xl border border-zinc-200 p-6 sm:p-8 lg:p-10 animate-fade-in-down dark:border-zinc-800 bg-[linear-gradient(160deg,#ecfdf5_0%,#ffffff_55%,#eef2ff_100%)] dark:bg-[linear-gradient(160deg,#041410_0%,#000000_55%,#08030f_100%)]">
           {/* Dotted texture */}
           <div
             className="pointer-events-none absolute inset-0 opacity-40 dark:opacity-20"
@@ -99,7 +99,10 @@ export default async function Home() {
             <h2 className="font-display text-2xl font-bold mb-6">Quick Actions</h2>
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               {quickActions.map((action, i) => {
-                const featured = action.href === "/code" || action.href === "/chat";
+                const featured =
+                  action.href === "/code" ||
+                  action.href === "/chat" ||
+                  action.href === "/quiz";
                 return (
                   <Link
                     key={action.title}

--- a/frontend/src/app/resources/page.tsx
+++ b/frontend/src/app/resources/page.tsx
@@ -11,6 +11,44 @@ import { FolderOpen, ExternalLink, FileText, Download } from "lucide-react";
 
 type CategoryMap = Record<string, { title: string; url: string }[]>;
 
+/** Colored file-type badge derived from a file name's extension. */
+function FileBadge({ name }: { name?: string | null }) {
+  const ext = (name?.split(".").pop() || "file").toUpperCase();
+  const palette: Record<string, string> = {
+    PDF: "bg-red-50 text-red-600 dark:bg-red-500/10 dark:text-red-400",
+    IPYNB: "bg-orange-50 text-orange-600 dark:bg-orange-500/10 dark:text-orange-400",
+    PPTX: "bg-amber-50 text-amber-600 dark:bg-amber-500/10 dark:text-amber-400",
+    PPT: "bg-amber-50 text-amber-600 dark:bg-amber-500/10 dark:text-amber-400",
+    DOCX: "bg-blue-50 text-blue-600 dark:bg-blue-500/10 dark:text-blue-400",
+    DOC: "bg-blue-50 text-blue-600 dark:bg-blue-500/10 dark:text-blue-400",
+    PY: "bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400",
+  };
+  const cls = palette[ext] || "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300";
+  return (
+    <span className={`flex-shrink-0 rounded-md px-2 py-1 text-[10px] font-bold tracking-wider ${cls}`}>
+      .{ext}
+    </span>
+  );
+}
+
+/** Uppercase section header with an icon on the left and a count on the right. */
+function SectionHeader({ label, count, unit }: { label: string; count: number; unit: string }) {
+  return (
+    <div className="mb-3 flex items-center justify-between px-1">
+      <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.25em] text-zinc-500 dark:text-zinc-400">
+        <FileText className="h-4 w-4" />
+        {label}
+      </div>
+      <span className="text-xs text-zinc-400 dark:text-zinc-500">
+        {count} {unit}
+      </span>
+    </div>
+  );
+}
+
+const ROW_CARD =
+  "flex items-center gap-4 rounded-2xl border border-zinc-200 bg-white px-4 py-3.5 shadow-sm transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900";
+
 export default function ResourcesPage() {
   const { token } = useAuthToken();
   const [categories, setCategories] = useState<CategoryMap>({});
@@ -68,14 +106,40 @@ export default function ResourcesPage() {
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   };
 
+  // Group downloadable files by their category so each becomes a labeled section.
+  const filesByCategory = fileResources.reduce<Record<string, Resource[]>>((acc, r) => {
+    const key = r.category || "Course materials";
+    (acc[key] ||= []).push(r);
+    return acc;
+  }, {});
+  const fileSections = Object.entries(filesByCategory);
+
+  const totalLinks = categoryEntries.reduce((n, [, links]) => n + links.length, 0);
+  const totalFiles = fileResources.length + uploads.length;
+  const totalDocs = totalFiles + totalLinks;
+  const isEmpty = !loading && !error && totalDocs === 0;
+
   return (
     <PageShell className="max-w-5xl" contentClassName="gap-8" noCard>
       <PageHero
         icon={FolderOpen}
-        title="Resource"
-        accent="Hub"
-        subtitle="Lecture slides, Canvas links, readings, and uploaded files — curated for INFO 5731 in one place."
+        eyebrow="Resources"
+        title="Everything your"
+        accent="tutor cites."
+        subtitle="Slides, readings, and code demos — indexed and searchable from the chat."
+        actions={
+          <div className="rounded-2xl border border-zinc-200 bg-white/80 px-5 py-4 shadow-sm backdrop-blur dark:border-zinc-800 dark:bg-zinc-900/70">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.25em] text-zinc-400 dark:text-zinc-500">
+              Indexed
+            </p>
+            <p className="font-display text-2xl font-bold text-emerald-600 dark:text-emerald-400">
+              {totalDocs} docs
+            </p>
+            <p className="text-xs text-zinc-400 dark:text-zinc-500">· {totalFiles} files</p>
+          </div>
+        }
       />
+
       {error && (
         <p className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-400">
           {error}
@@ -92,81 +156,94 @@ export default function ResourcesPage() {
         </div>
       )}
 
-      {/* Link Resources by Category */}
-      {!loading && (
-        <section className="space-y-4">
-          {categoryEntries.map(([name, links]) => (
-            <article key={name} className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
-              <h2 className="flex items-center gap-3 text-xl font-semibold text-zinc-900 dark:text-white">
-                <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400">
-                  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                  </svg>
-                </span>
-                {name}
-              </h2>
-              <ul className="mt-4 space-y-3 text-sm">
-                {links.map((link) => (
-                  <li key={link.url} className="flex items-start gap-3">
-                    <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-                      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-                      </svg>
-                    </span>
-                    <a href={link.url} target="_blank" rel="noreferrer" className="font-medium text-blue-600 hover:underline dark:text-blue-400">
-                      {link.title}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </article>
-          ))}
-
-          {categoryEntries.length === 0 && !error && !loading && (
-            <div className="flex flex-col items-center gap-3 rounded-2xl border border-zinc-200 bg-zinc-50 p-8 text-center dark:border-zinc-800 dark:bg-zinc-900/30">
-              <FolderOpen className="h-10 w-10 text-zinc-300 dark:text-zinc-600" />
-              <p className="text-sm text-zinc-500 dark:text-zinc-400">No curated resources available yet.</p>
+      {/* Downloadable course files, grouped by category */}
+      {!loading &&
+        fileSections.map(([name, files]) => (
+          <section key={name} className="animate-fade-in-up">
+            <SectionHeader label={name} count={files.length} unit={files.length === 1 ? "file" : "files"} />
+            <div className="space-y-3">
+              {files.map((res) => (
+                <div key={res.id} className={ROW_CARD}>
+                  <FileBadge name={res.file_name} />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-semibold text-zinc-900 dark:text-white">{res.title}</p>
+                    {res.description && (
+                      <p className="truncate text-xs text-zinc-500 dark:text-zinc-400">{res.description}</p>
+                    )}
+                  </div>
+                  <span className="hidden flex-shrink-0 text-xs tabular-nums text-zinc-400 dark:text-zinc-500 sm:block">
+                    {formatBytes(res.file_size_bytes)}
+                  </span>
+                  <button
+                    onClick={() => handleDownload(res.id)}
+                    disabled={downloading === res.id}
+                    aria-label={`Download ${res.title}`}
+                    className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-zinc-200 text-zinc-500 transition hover:bg-zinc-50 hover:text-zinc-900 disabled:opacity-50 dark:border-zinc-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-white"
+                  >
+                    <Download className={`h-4 w-4 ${downloading === res.id ? "animate-pulse" : ""}`} />
+                  </button>
+                </div>
+              ))}
             </div>
-          )}
-        </section>
-      )}
+          </section>
+        ))}
 
-      {/* Course Materials (file downloads) */}
-      {!loading && fileResources.length > 0 && (
-        <section className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-          <h2 className="flex items-center gap-3 text-xl font-semibold text-zinc-900 dark:text-white">
-            <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-100 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400">
-              <FileText className="h-5 w-5" />
-            </span>
-            Course Materials
-          </h2>
-          <div className="mt-4 space-y-3">
-            {fileResources.map((res) => (
-              <div
-                key={res.id}
-                className="flex items-center justify-between rounded-xl border border-zinc-100 bg-zinc-50 p-4 transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-800/50"
-              >
+      {/* Curated external links, grouped by category */}
+      {!loading &&
+        categoryEntries.map(([name, links]) => (
+          <section key={name} className="animate-fade-in-up">
+            <SectionHeader label={name} count={links.length} unit={links.length === 1 ? "link" : "links"} />
+            <div className="space-y-3">
+              {links.map((link) => (
+                <a
+                  key={link.url}
+                  href={link.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={`group ${ROW_CARD} hover:border-emerald-300 dark:hover:border-emerald-700`}
+                >
+                  <span className="flex-shrink-0 rounded-md bg-emerald-50 px-2 py-1 text-[10px] font-bold tracking-wider text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400">
+                    .LINK
+                  </span>
+                  <p className="min-w-0 flex-1 truncate font-semibold text-zinc-900 transition group-hover:text-emerald-600 dark:text-white dark:group-hover:text-emerald-400">
+                    {link.title}
+                  </p>
+                  <ExternalLink className="h-4 w-4 flex-shrink-0 text-zinc-400 dark:text-zinc-500" />
+                </a>
+              ))}
+            </div>
+          </section>
+        ))}
+
+      {/* Knowledge uploads */}
+      {!loading && uploads.length > 0 && (
+        <section className="animate-fade-in-up">
+          <SectionHeader label="Uploads" count={uploads.length} unit={uploads.length === 1 ? "file" : "files"} />
+          <div className="space-y-3">
+            {uploads.map((upload) => (
+              <div key={upload.id} className={ROW_CARD}>
+                <FileBadge name={upload.file_name} />
                 <div className="min-w-0 flex-1">
-                  <p className="font-semibold text-zinc-900 dark:text-white">{res.title}</p>
-                  {res.description && (
-                    <p className="mt-0.5 text-xs text-zinc-600 dark:text-zinc-400">{res.description}</p>
-                  )}
-                  <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-                    {res.file_name} · {formatBytes(res.file_size_bytes)} · {res.category}
+                  <p className="truncate font-semibold text-zinc-900 dark:text-white">{upload.file_name}</p>
+                  <p className="truncate text-xs text-zinc-500 dark:text-zinc-400">
+                    Uploaded {new Date(upload.uploaded_at).toLocaleDateString()}
                   </p>
                 </div>
-                <button
-                  onClick={() => handleDownload(res.id)}
-                  disabled={downloading === res.id}
-                  className="ml-4 flex items-center gap-2 rounded-lg bg-purple-100 px-3 py-2 text-xs font-medium text-purple-700 transition hover:bg-purple-200 disabled:opacity-50 dark:bg-purple-900/30 dark:text-purple-400 dark:hover:bg-purple-900/50"
-                >
-                  <Download className="h-3.5 w-3.5" />
-                  {downloading === res.id ? "…" : "Download"}
-                </button>
+                <span className="hidden flex-shrink-0 text-xs tabular-nums text-zinc-400 dark:text-zinc-500 sm:block">
+                  {Math.round(upload.size_bytes / 1024)} KB
+                </span>
               </div>
             ))}
           </div>
         </section>
+      )}
+
+      {/* Empty state */}
+      {isEmpty && (
+        <div className="flex flex-col items-center gap-3 rounded-2xl border border-zinc-200 bg-zinc-50 p-10 text-center dark:border-zinc-800 dark:bg-zinc-900/30">
+          <FolderOpen className="h-10 w-10 text-zinc-300 dark:text-zinc-600" />
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">No curated resources available yet.</p>
+        </div>
       )}
 
       {/* Suggestion CTA */}
@@ -174,31 +251,11 @@ export default function ResourcesPage() {
         <section className="rounded-2xl border border-dashed border-zinc-200 bg-zinc-50 p-6 text-sm text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-400">
           <p>
             See something missing?{" "}
-            <Link href="/feedback" className="font-semibold text-blue-600 hover:underline dark:text-blue-400">
+            <Link href="/feedback" className="font-semibold text-emerald-600 hover:underline dark:text-emerald-400">
               Suggest a resource
             </Link>{" "}
             and we&apos;ll review it for the next release.
           </p>
-        </section>
-      )}
-
-      {/* Knowledge Uploads */}
-      {uploads.length > 0 && (
-        <section className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-          <div className="flex items-center justify-between">
-            <h2 className="text-xl font-semibold text-zinc-900 dark:text-white">Knowledge uploads</h2>
-          </div>
-          <div className="mt-4 space-y-3 max-h-[360px] overflow-auto pr-1 text-sm">
-            {uploads.map((upload) => (
-              <div key={upload.id} className="rounded-xl border border-zinc-100 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-800/50">
-                <p className="font-semibold text-zinc-900 dark:text-white">{upload.file_name}</p>
-                <p className="text-xs text-zinc-500 dark:text-zinc-400">Stored at {upload.path}</p>
-                <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                  {Math.round(upload.size_bytes / 1024)} KB · Uploaded {new Date(upload.uploaded_at).toLocaleString()}
-                </p>
-              </div>
-            ))}
-          </div>
         </section>
       )}
     </PageShell>

--- a/frontend/src/components/page-hero.tsx
+++ b/frontend/src/components/page-hero.tsx
@@ -10,6 +10,8 @@ interface PageHeroProps {
   subtitle?: ReactNode;
   /** Optional Lucide icon shown as a chip above the title. */
   icon?: LucideIcon;
+  /** Optional uppercase label rendered as a pill (with `icon`) above the title. */
+  eyebrow?: string;
   /** Extra classes for the outer header element. */
   className?: string;
   /** Optional right-aligned slot (e.g. action buttons). */
@@ -27,6 +29,7 @@ export function PageHero({
   accent,
   subtitle,
   icon: Icon,
+  eyebrow,
   className,
   actions,
 }: PageHeroProps) {
@@ -34,7 +37,7 @@ export function PageHero({
     "relative overflow-hidden rounded-3xl border border-zinc-200 p-6 sm:p-8 lg:p-10",
     "animate-fade-in-down dark:border-zinc-800",
     "bg-[linear-gradient(160deg,#ecfdf5_0%,#ffffff_55%,#eef2ff_100%)]",
-    "dark:bg-[linear-gradient(160deg,#04201d_0%,#0f172a_55%,#1a193f_100%)]",
+    "dark:bg-[linear-gradient(160deg,#041410_0%,#000000_55%,#08030f_100%)]",
     className,
   ]
     .filter(Boolean)
@@ -63,10 +66,17 @@ export function PageHero({
 
       <div className="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          {Icon && (
-            <span className="mb-4 inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/70 text-emerald-600 shadow-sm ring-1 ring-zinc-200 dark:bg-white/10 dark:text-emerald-400 dark:ring-white/10">
-              <Icon className="h-5 w-5" />
+          {eyebrow ? (
+            <span className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-600 dark:text-emerald-400">
+              {Icon && <Icon className="h-3.5 w-3.5" />}
+              {eyebrow}
             </span>
+          ) : (
+            Icon && (
+              <span className="mb-4 inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/70 text-emerald-600 shadow-sm ring-1 ring-zinc-200 dark:bg-white/10 dark:text-emerald-400 dark:ring-white/10">
+                <Icon className="h-5 w-5" />
+              </span>
+            )
           )}
           <h1 className="font-display text-3xl font-bold leading-[1.05] tracking-tight text-zinc-900 dark:text-white sm:text-4xl lg:text-5xl">
             {title}


### PR DESCRIPTION
## Summary
Five UI updates, continuing the Claude Design Language work.

1. **Home** — "Generate a quiz" Quick Action now uses the shared green→indigo `card-gradient` (all three featured cards consistent).
2. **Chat** — removed the "GROUNDED IN INFO 5731 CORPUS" badge from the welcome screen.
3. **Dark mode → truly black** — retargeted the legacy `.theme-dark` slate `!important` overrides + `--background` to a neutral near-black palette (`#000` / `#141414` / `#262626`) and darkened the hero gradients. (The slate overrides used `!important` and beat the `dark:bg-zinc-900` utilities, so this is the correct single lever; the one surviving `#0f172a` is the light-mode foreground token.)
4. **About** — full redesign: ABOUT hero pill, 6-card Key Features grid with mint icon chips, 4-card Technology Stack row, compact Developer card (avatar + GitHub/LinkedIn/Email pills). Drops the old photo/bio/Contact section.
5. **Resources** — reskin to the new UI language: RESOURCES hero with an INDEXED stat card (real derived counts), per-category section headers with file counts, and row cards with colored file-type badges (`.PDF`/`.IPYNB`/…), sizes, and download buttons. Existing data flow, grouping, presigned downloads, uploads, and states preserved.

Plus: `PageHero` gains an optional `eyebrow` pill prop (icon + label); existing icon-chip callers are unaffected.

## Verification
- `tsc --noEmit` clean; ESLint 0 errors on changed files.
- Frontend + backend rebuilt in Docker; both healthy.
- `/`, `/about`, `/resources`, `/chat` return HTTP 200; new hero/section content verified in served HTML; compiled CSS confirms navy slate surfaces removed (neutral near-black present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added eyebrow labels to page headers for enhanced context.

* **Style**
  * Redesigned About page with Key Features grid and Technology Stack display.
  * Updated dark mode with darker, refined color palette.
  * Reorganized Resources page with improved file organization and link displays.
  * Refined chat welcome screen styling.
  * Enhanced homepage dark-mode gradient effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->