### PR TITLE
fix(ci): point Aura Resume Guard at current instance (57036f35)

### DIFF
--- a/.github/workflows/neo4j-aura-resume.yml
+++ b/.github/workflows/neo4j-aura-resume.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      NEO4J_AURA_INSTANCE_ID: ${{ secrets.NEO4J_AURA_INSTANCE_ID || vars.NEO4J_AURA_INSTANCE_ID || 'b0e9fb13' }}
+      NEO4J_AURA_INSTANCE_ID: ${{ secrets.NEO4J_AURA_INSTANCE_ID || vars.NEO4J_AURA_INSTANCE_ID || '57036f35' }}
       NEO4J_AURA_CLIENT_ID: ${{ secrets.NEO4J_AURA_CLIENT_ID || secrets.NEO4J_AURA_API_CLIENT_ID || secrets.AURA_CLIENT_ID || vars.NEO4J_AURA_CLIENT_ID || vars.NEO4J_AURA_API_CLIENT_ID || vars.AURA_CLIENT_ID || '' }}
       NEO4J_AURA_CLIENT_SECRET: ${{ secrets.NEO4J_AURA_CLIENT_SECRET || secrets.NEO4J_AURA_API_CLIENT_SECRET || secrets.AURA_CLIENT_SECRET || '' }}
       # Aura free-tier instances routinely take 7-12 minutes to resume from a


### PR DESCRIPTION
## Summary
The AuraDB instance `b0e9fb13` lost its (unrecoverable) database password and was rejecting all auth — breaking the Knowledge Graph dashboard. It's been deleted and replaced with a new free Aura instance **`57036f35`** (data regenerates from app usage). The EC2 backend env (`~/smart-tutor.env`) is already updated and verified — the KG endpoint now returns 200 with no error, and Neo4j queries succeed.

This PR updates the **Aura Resume Guard** workflow's hardcoded `NEO4J_AURA_INSTANCE_ID` fallback from the deleted `b0e9fb13` to the live `57036f35`, so the scheduled guard targets the correct instance even if the `NEO4J_AURA_INSTANCE_ID` Actions variable is ever removed. The runtime value is also set via that Actions variable (already configured), and the guard was dispatched and **passed** against `57036f35`.

## Verification
- Resume Guard run on `57036f35`: *"initial status: running → No resume needed"*, conclusion success.
- KG admin endpoint: HTTP 200, no `error` field (was "Failed to fetch knowledge graph metrics").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->