### PR TITLE
feat(ops+ux): schedule EC2 to weekday business hours with graceful downtime

### DIFF
--- a/.github/workflows/ec2-schedule.yml
+++ b/.github/workflows/ec2-schedule.yml
@@ -38,12 +38,16 @@ jobs:
     steps:
       - name: Decide action (DST-aware, weekday-gated)
         id: decide
+        # Pass the dispatch input through the environment rather than
+        # interpolating ${{ ... }} directly into the shell — avoids script
+        # injection (flagged by run-shell-injection SAST rules).
+        env:
+          MANUAL_ACTION: ${{ github.event.inputs.action }}
         run: |
           set -euo pipefail
-          MANUAL="${{ github.event.inputs.action }}"
-          if [ -n "$MANUAL" ]; then
-            echo "Manual dispatch: $MANUAL"
-            echo "action=$MANUAL" >> "$GITHUB_OUTPUT"
+          if [ -n "$MANUAL_ACTION" ]; then
+            echo "Manual dispatch: $MANUAL_ACTION"
+            echo "action=$MANUAL_ACTION" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           NOW="$(TZ='America/Chicago' date '+%A %Y-%m-%d %H:%M %Z')"

--- a/.github/workflows/ec2-schedule.yml
+++ b/.github/workflows/ec2-schedule.yml
@@ -1,0 +1,86 @@
+name: EC2 Schedule (weekday business hours)
+
+# Stops the production EC2 instance outside Mon–Fri 09:00–17:00 America/Chicago
+# to cut the always-on compute bill. The Elastic IP (52.2.3.101) survives
+# stop/start, and every container uses restart=unless-stopped, so the app
+# comes back up automatically on the morning boot.
+#
+# GitHub cron is UTC-only, so each boundary is scheduled at BOTH its CDT and
+# CST UTC time; the job then gates on the real America/Chicago hour, making the
+# 09:00/17:00 boundaries correct across daylight-saving changes. The two extra
+# fires per day are cheap no-ops.
+
+on:
+  schedule:
+    # Start 09:00 America/Chicago  → 14:00 UTC (CDT) and 15:00 UTC (CST)
+    - cron: "0 14 * * 1-5"
+    - cron: "0 15 * * 1-5"
+    # Stop  17:00 America/Chicago  → 22:00 UTC (CDT) and 23:00 UTC (CST)
+    - cron: "0 22 * * 1-5"
+    - cron: "0 23 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Manually start or stop the instance
+        type: choice
+        options: [start, stop]
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  INSTANCE_ID: i-0c35826b951e9dd6f
+
+jobs:
+  schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide action (DST-aware, weekday-gated)
+        id: decide
+        run: |
+          set -euo pipefail
+          MANUAL="${{ github.event.inputs.action }}"
+          if [ -n "$MANUAL" ]; then
+            echo "Manual dispatch: $MANUAL"
+            echo "action=$MANUAL" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          NOW="$(TZ='America/Chicago' date '+%A %Y-%m-%d %H:%M %Z')"
+          HOUR="$(TZ='America/Chicago' date +%H)"
+          DOW="$(TZ='America/Chicago' date +%u)"   # 1=Mon .. 7=Sun
+          echo "Central time: $NOW (hour=$HOUR dow=$DOW)"
+          if [ "$DOW" -gt 5 ]; then
+            echo "Weekend — no action."
+            echo "action=none" >> "$GITHUB_OUTPUT"
+          elif [ "$HOUR" = "09" ]; then
+            echo "action=start" >> "$GITHUB_OUTPUT"
+          elif [ "$HOUR" = "17" ]; then
+            echo "action=stop" >> "$GITHUB_OUTPUT"
+          else
+            echo "Hour $HOUR is not a schedule boundary — no action."
+            echo "action=none" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.decide.outputs.action == 'start' || steps.decide.outputs.action == 'stop'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Start instance
+        if: steps.decide.outputs.action == 'start'
+        run: |
+          set -euo pipefail
+          aws ec2 start-instances --instance-ids "$INSTANCE_ID"
+          aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+          echo "✓ Started $INSTANCE_ID (containers auto-restart via restart=unless-stopped)"
+
+      - name: Stop instance
+        if: steps.decide.outputs.action == 'stop'
+        run: |
+          set -euo pipefail
+          aws ec2 stop-instances --instance-ids "$INSTANCE_ID"
+          echo "✓ Stop requested for $INSTANCE_ID"

--- a/frontend/src/app/api/backend/[...path]/route.ts
+++ b/frontend/src/app/api/backend/[...path]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { posix } from "path";
+import { getMaintenanceState } from "@/lib/maintenance";
 
 // Increase timeout for long-running operations like initial S3 index download (can take up to 3-4 minutes)
 export const maxDuration = 300;
@@ -165,7 +166,32 @@ async function proxyRequest(request: NextRequest, path: string[]) {
     (init as Record<string, unknown>).duplex = "half";
   }
 
-  const response = await fetch(url, init);
+  let response: Response;
+  try {
+    response = await fetch(url, init);
+  } catch {
+    // The backend is unreachable. This is expected during the scheduled
+    // stop window (see lib/maintenance + .github/workflows/ec2-schedule.yml),
+    // and otherwise indicates a real outage. Either way, return a clean 503
+    // with a classified reason instead of letting the error surface as a 500.
+    const { isDown, resumesLabel } = getMaintenanceState();
+    return new Response(
+      JSON.stringify({
+        detail: isDown
+          ? `Scheduled maintenance — the AI tutor is offline outside Mon–Fri 9 AM–5 PM CT.${resumesLabel ? ` Service resumes ${resumesLabel}.` : ""}`
+          : "Backend temporarily unavailable. Please try again shortly.",
+        reason: isDown ? "scheduled_maintenance" : "backend_unavailable",
+        resumes: isDown ? resumesLabel : null,
+      }),
+      {
+        status: 503,
+        headers: {
+          "Content-Type": "application/json",
+          "Retry-After": "300",
+        },
+      }
+    );
+  }
   const proxyHeaders = new Headers();
   appendResponseHeaders(proxyHeaders, response.headers);
   // NOTE: Do NOT delete the Content-Security-Policy header — removing it would

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -523,11 +523,21 @@ function ChatWorkspaceContent() {
         return;
       }
 
-      // Handle LLM unavailable / server busy (503)
+      // Handle LLM unavailable / server busy / scheduled downtime (503)
       if (response.status === 503) {
-        const err = await response.json();
-        const secs = err.detail?.retry_after || 60;
-        toast.error(`LLM unavailable. Retrying in ${secs}s — the service may be overloaded.`);
+        const err = await response.json().catch(() => ({}));
+        if (err.reason === "scheduled_maintenance") {
+          // Backend is intentionally stopped outside business hours.
+          toast.error(
+            err.detail ||
+              "Scheduled maintenance — the AI tutor is offline outside Mon–Fri 9 AM–5 PM CT."
+          );
+        } else if (err.reason === "backend_unavailable") {
+          toast.error("The tutor backend is temporarily unavailable. Please try again shortly.");
+        } else {
+          const secs = err.detail?.retry_after || 60;
+          toast.error(`LLM unavailable. Retrying in ${secs}s — the service may be overloaded.`);
+        }
         updateActiveSessionMessages((messages) => messages.slice(0, -1));
         setIsStreaming(false);
         return;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/context/theme-context";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ToastProvider } from "@/components/toast-provider";
 import { AnnouncementToaster } from "@/components/announcement-toaster";
+import { MaintenanceBanner } from "@/components/maintenance-banner";
 import { PostHogProvider } from "@/components/posthog-provider";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/next";
@@ -59,6 +60,7 @@ export default function RootLayout({
             <ThemeProvider>
               <ToastProvider />
               <AnnouncementToaster />
+              <MaintenanceBanner />
               <SiteChrome navLinks={navLinks}>{children}</SiteChrome>
             </ThemeProvider>
           </ErrorBoundary>

--- a/frontend/src/components/maintenance-banner.tsx
+++ b/frontend/src/components/maintenance-banner.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Wrench } from "lucide-react";
+import {
+  getMaintenanceState,
+  WINDOW_LABEL,
+  type MaintenanceState,
+} from "@/lib/maintenance";
+
+/**
+ * Site-wide notice shown while the backend is in its scheduled-down window.
+ *
+ * The state is computed client-side from the local clock (see lib/maintenance),
+ * so it appears immediately without waiting for a backend request to fail.
+ * Initial render is empty to avoid a hydration mismatch; the effect fills it in
+ * on the client and re-checks every minute so the banner clears itself at 9 AM.
+ */
+export function MaintenanceBanner() {
+  const [state, setState] = useState<MaintenanceState>({
+    isDown: false,
+    resumesLabel: null,
+  });
+
+  useEffect(() => {
+    const update = () => setState(getMaintenanceState());
+    update();
+    const id = setInterval(update, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!state.isDown) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="sticky top-0 z-50 flex items-center justify-center gap-2 border-b border-amber-300/60 bg-amber-50 px-4 py-2 text-center text-sm font-medium text-amber-900 dark:border-amber-500/30 dark:bg-amber-950/60 dark:text-amber-200"
+    >
+      <Wrench className="h-4 w-4 shrink-0" />
+      <span>
+        Scheduled maintenance — the AI tutor is offline outside {WINDOW_LABEL}.
+        {state.resumesLabel ? ` Service resumes ${state.resumesLabel}.` : ""}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/lib/maintenance.ts
+++ b/frontend/src/lib/maintenance.ts
@@ -1,0 +1,80 @@
+/**
+ * Scheduled-downtime helper.
+ *
+ * The production EC2 instance is stopped outside Mon–Fri 09:00–17:00
+ * America/Chicago (see .github/workflows/ec2-schedule.yml) to cut the
+ * always-on compute bill. This module is the single source of truth for that
+ * window so both the browser (proactive maintenance banner) and the backend
+ * proxy (classifying an unreachable backend) agree on when we're "down".
+ *
+ * It uses Intl with an explicit timeZone, so it is DST-correct year-round
+ * without hardcoding UTC offsets.
+ */
+
+export const MAINTENANCE_TZ = "America/Chicago";
+export const ON_START_HOUR = 9; // 09:00 CT — instance starts
+export const ON_END_HOUR = 17; // 17:00 CT — instance stops
+export const WINDOW_LABEL = "Mon–Fri 9 AM–5 PM CT";
+
+const WEEKDAY_TO_NUM: Record<string, number> = {
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+  Sunday: 7,
+};
+
+type ChicagoParts = { dow: number; hour: number };
+
+function chicagoParts(now: Date): ChicagoParts {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: MAINTENANCE_TZ,
+    weekday: "long",
+    hour: "2-digit",
+    hour12: false,
+  }).formatToParts(now);
+
+  const get = (type: string) =>
+    parts.find((p) => p.type === type)?.value ?? "";
+
+  let hour = parseInt(get("hour"), 10);
+  if (Number.isNaN(hour) || hour === 24) hour = 0; // some runtimes emit "24" at midnight
+  const dow = WEEKDAY_TO_NUM[get("weekday")] ?? 1;
+  return { dow, hour };
+}
+
+export type MaintenanceState = {
+  /** True when the instance is scheduled to be stopped right now. */
+  isDown: boolean;
+  /** Human label for when service resumes, e.g. "today at 9:00 AM CT". */
+  resumesLabel: string | null;
+};
+
+/**
+ * Compute whether we're currently inside the scheduled-down window, and a
+ * friendly label for when the service comes back.
+ */
+export function getMaintenanceState(now: Date = new Date()): MaintenanceState {
+  const { dow, hour } = chicagoParts(now);
+  const isWeekend = dow > 5;
+  const beforeOpen = hour < ON_START_HOUR;
+  const afterClose = hour >= ON_END_HOUR;
+  const isDown = isWeekend || beforeOpen || afterClose;
+
+  if (!isDown) return { isDown: false, resumesLabel: null };
+
+  let resumesLabel: string;
+  if (!isWeekend && beforeOpen) {
+    // Same weekday, before opening → comes back this morning.
+    resumesLabel = "today at 9:00 AM CT";
+  } else if (dow === 5 || dow === 6 || dow === 7) {
+    // Friday after close, or any time on the weekend → next Monday.
+    resumesLabel = "Monday at 9:00 AM CT";
+  } else {
+    // Mon–Thu after close → next morning.
+    resumesLabel = "tomorrow at 9:00 AM CT";
+  }
+  return { isDown: true, resumesLabel };
+}


### PR DESCRIPTION
## What
1. **Schedule** (`.github/workflows/ec2-schedule.yml`): stops the production EC2 instance outside **Mon–Fri 09:00–17:00 America/Chicago**, starts it each weekday morning.
2. **Graceful downtime (Option D)**: instead of 10-second hangs and generic 500s while the box is stopped, users get a clear, instant maintenance experience.

## Why
The backend runs on one always-on `t3a.medium` at full on-demand rate — **~$24/mo, ~63% of the AWS bill** — but is only needed during business hours. Scheduling to weekday 9–5 → **~$18.5/mo saved**. Option D makes the resulting downtime user-friendly.

## How
**Schedule**
- DST-proof: each boundary fires at both its CDT and CST UTC time; the job gates on the real `America/Chicago` hour. Extra fires are no-ops.
- Uses existing `AWS_*` repo secrets (key has `ec2:Start/StopInstances`, dry-run verified).
- Elastic IP `52.2.3.101` persists across stop/start; all 11 containers are `restart=unless-stopped`, so the stack auto-recovers on the morning boot.
- `workflow_dispatch` start/stop for manual override (input passed via env, not shell-interpolated — clears the run-shell-injection SAST rule).

**Graceful downtime**
- `lib/maintenance.ts`: single source of truth for the window (DST-aware via `Intl`), shared by client + proxy.
- `MaintenanceBanner`: site-wide notice computed client-side from the local clock, so it shows immediately without a failed request; clears itself at 9 AM.
- Backend proxy: wraps the upstream fetch → returns a clean **503** classified as `scheduled_maintenance` vs `backend_unavailable`, instead of an unhandled 500.
- Chat: recognizes the maintenance 503 and shows the right message.

## Verified locally
`tsc --noEmit` ✓, `eslint` ✓, proxy contract test ✓, schedule logic unit-checked across CDT/CST/weekend boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)