### PR TITLE
Add fallback text to Slack notification attachments

### DIFF
--- a/.github/actions/send-slack-notification/action.yml
+++ b/.github/actions/send-slack-notification/action.yml
@@ -101,6 +101,7 @@ runs:
         python3 - <<'PY'
         import json
         import os
+        import re
         import sys
 
         # --- Status normalisation ---------------------------------------------
@@ -193,10 +194,20 @@ runs:
                 "elements": [{"type": "mrkdwn", "text": " | ".join(footer_parts)}],
             })
 
+        # Plain-text summary for clients that don't render Block Kit — mobile
+        # push notifications, desktop notification banners, IRC-style
+        # clients, screen readers, and any tool that lists/searches messages
+        # by preview text. Without this, attachments that only carry
+        # `blocks` show up blank everywhere except the full message view.
+        # Slack recommends fallback contain no markup, so strip mrkdwn
+        # emphasis and :emoji: shortcodes from the snippet.
+        message_snippet = re.sub(r"^:\w+:\s*|\*", "", message.splitlines()[0]) if message else ""
+        fallback = f"{status_label}: {verbiage} — {message_snippet[:200] or '(no message)'}"
+
         payload = {
             "username": "GitHub Actions",
             "icon_emoji": ":github:",
-            "attachments": [{"color": color, "blocks": blocks}],
+            "attachments": [{"color": color, "fallback": fallback, "blocks": blocks}],
         }
 
         # --- Size guard --------------------------------------------------------


### PR DESCRIPTION
## Summary
- CI/CD Slack notifications (deploy results, PR reviews, observability bootstrap) were showing as "[no preview available]" anywhere a client shows a message preview instead of the full Block Kit view — confirmed via the Slack API that recent notify-step messages all have empty preview/fallback text, while Alertmanager's alerts (which set a plain top-level `text` field, a different payload shape) render with full content.
- `.github/actions/send-slack-notification/action.yml` built `attachments[0].blocks` but never set `attachments[0].fallback`. Per Slack's Block Kit docs, `fallback` is what powers previews for clients that don't render blocks — mobile push notifications, desktop notification banners, IRC-style clients, screen readers, and any tool listing/searching messages by preview text.
- Added a `fallback` field: `"{STATUS}: {verbiage} — {first line of message, markup/emoji-shortcode stripped}"`, per Slack's guidance that fallback should be plain text with no markup.

## Test plan
- [x] Extracted and syntax-checked the embedded Python payload builder
- [x] Rendered a sample payload locally end-to-end and confirmed `fallback` is present and clean (e.g. `"FAILED: Production Deploy — Production deploy SUCCEEDED"`)
- [ ] After merge: confirm the next CI/CD Slack notification shows real preview text instead of "[no preview available]"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack notification fallback content with a concise plain-text preview.
  * Notifications now include a normalized status and truncated message snippet when rich formatting is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->