### PR TITLE
Make /ready and /health actually check dependencies

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -211,26 +211,49 @@ async def sitemap():
 @app.get("/health")
 @limiter.limit("10/minute")  # Rate limit health checks
 async def health_check(request: Request):
-    """Simple health check endpoint"""
+    """Simple health check endpoint. Returns 503 when a core dependency
+    (database, redis, bedrock, neo4j, s3) is unhealthy so callers relying
+    on HTTP status (curl -f, uptime monitors) actually detect failure --
+    a "degraded" status (only a peripheral like langfuse/posthog is down)
+    still returns 200, since the app is substantively still serving."""
     from backend.health import HealthChecker
     health = HealthChecker.get_simple_health()
 
-    return {
-        **health,
-        "environment": config.ENVIRONMENT,
-        "version": "1.0.0"
-    }
+    status_code = 503 if health["status"] == "unhealthy" else 200
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            **health,
+            "environment": config.ENVIRONMENT,
+            "version": "1.0.0"
+        },
+    )
 
 
 @app.get("/ready")
 @limiter.limit("30/minute")
 async def readiness_check(request: Request):
-    """Lightweight readiness probe for deploys and load balancers."""
-    return {
-        "status": "ready",
-        "environment": config.ENVIRONMENT,
-        "version": "1.0.0"
-    }
+    """Readiness probe for deploys, rollbacks, and load balancers.
+
+    Checks only database and redis -- the dependencies nearly every
+    request needs -- and returns 503 when either is down. Deliberately
+    fast and cheap: this is Docker's HEALTHCHECK target, polled every 5s
+    for the entire lifetime of the container, so it must not carry the
+    latency or cost of the external checks (Bedrock, Neo4j, S3, Secrets
+    Manager) that live in /health instead.
+    """
+    from backend.health import HealthChecker
+    result = HealthChecker.get_liveness_core()
+
+    status_code = 200 if result["status"] == "ready" else 503
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            **result,
+            "environment": config.ENVIRONMENT,
+            "version": "1.0.0"
+        },
+    )
 
 
 @app.get("/health/detailed")

--- a/backend/health.py
+++ b/backend/health.py
@@ -118,6 +118,67 @@ class HealthChecker:
             }
 
     @staticmethod
+    def check_neo4j() -> Dict[str, Any]:
+        """Check Neo4j connectivity (knowledge graph)"""
+        try:
+            from backend.config import config
+
+            if not config.NEO4J_URI:
+                return {
+                    "status": "not_configured",
+                    "message": "NEO4J_URI is not set"
+                }
+
+            from backend.agents.neo4j_client import get_neo4j_client
+
+            get_neo4j_client().driver.verify_connectivity()
+
+            return {
+                "status": "healthy",
+                "message": "Connected"
+            }
+
+        except Exception as e:
+            # Includes a paused Aura instance -- reported as unhealthy here
+            # rather than triggering an in-request resume, which can take
+            # minutes; the scheduled resume-guard workflow owns that job.
+            logger.error(f"Neo4j health check failed: {e}")
+            return {
+                "status": "unhealthy",
+                "error": str(e)
+            }
+
+    @staticmethod
+    def check_s3() -> Dict[str, Any]:
+        """Check S3 connectivity (vector store / uploads)"""
+        try:
+            from backend.config import config
+
+            if not config.S3_VECTORS_BUCKET:
+                return {
+                    "status": "not_configured",
+                    "message": "S3_VECTORS_BUCKET is not set"
+                }
+
+            from backend.cloud.aws_helpers import get_boto3_client
+
+            s3 = get_boto3_client("s3")
+            s3.head_bucket(Bucket=config.S3_VECTORS_BUCKET)
+
+            return {
+                "status": "healthy",
+                "bucket": config.S3_VECTORS_BUCKET,
+                "message": "Accessible"
+            }
+
+        except Exception as e:
+            logger.error(f"S3 health check failed: {e}")
+            return {
+                "status": "unhealthy",
+                "error": str(e)
+            }
+
+    @staticmethod
     def check_secrets_manager() -> Dict[str, Any]:
         """Check AWS Secrets Manager access"""
         try:
@@ -203,6 +264,12 @@ class HealthChecker:
                 "error": str(e)
             }
 
+    # Components the app cannot meaningfully serve traffic without. A
+    # failure here means "unhealthy" (gates deploys/rollbacks); a failure
+    # in anything else means "degraded" (observability/secrets-cache blips
+    # that shouldn't block a promotion on their own).
+    CORE_COMPONENTS = {"database", "redis", "bedrock", "neo4j", "s3"}
+
     @classmethod
     def get_detailed_health(cls) -> Dict[str, Any]:
         """
@@ -215,6 +282,8 @@ class HealthChecker:
             "database": cls.check_database(),
             "redis": cls.check_redis(),
             "bedrock": cls.check_bedrock(),
+            "neo4j": cls.check_neo4j(),
+            "s3": cls.check_s3(),
             "secrets_manager": cls.check_secrets_manager(),
             "jwt_blacklist": cls.check_jwt_blacklist(),
             "langfuse": cls.check_langfuse(),
@@ -226,8 +295,11 @@ class HealthChecker:
             name for name, check in checks.items()
             if check.get("status") == "unhealthy"
         ]
+        unhealthy_core = [name for name in unhealthy_components if name in cls.CORE_COMPONENTS]
 
-        if unhealthy_components:
+        if unhealthy_core:
+            overall_status = "unhealthy"
+        elif unhealthy_components:
             overall_status = "degraded"
         else:
             overall_status = "healthy"
@@ -252,4 +324,30 @@ class HealthChecker:
         return {
             "status": detailed["status"],
             "timestamp": detailed["timestamp"]
+        }
+
+    @classmethod
+    def get_liveness_core(cls) -> Dict[str, Any]:
+        """
+        Fast, cheap check of only the dependencies nearly every request
+        needs. This backs /ready, which Docker's HEALTHCHECK polls every
+        5s for the entire lifetime of the container -- deliberately
+        excludes slower/external checks (Bedrock, Neo4j, S3, Secrets
+        Manager, Langfuse, PostHog) that belong in /health instead.
+
+        Returns:
+            Dict with status ("ready" or "unhealthy") and component checks
+        """
+        checks = {
+            "database": cls.check_database(),
+            "redis": cls.check_redis(),
+        }
+        unhealthy = [
+            name for name, check in checks.items()
+            if check.get("status") == "unhealthy"
+        ]
+        return {
+            "status": "unhealthy" if unhealthy else "ready",
+            "checks": checks,
+            "unhealthy_components": unhealthy if unhealthy else None
         }

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -20,11 +20,29 @@ class TestHealthEndpoints:
     def test_health_check(self, test_client):
         """Test basic health check"""
         response = test_client.get("/health")
-        assert response.status_code == 200
+        # /health returns 503 when a core dependency (database, redis,
+        # bedrock, neo4j, s3) is genuinely unreachable, so deploy/rollback
+        # gates can detect real failures instead of always seeing 200.
+        # This test environment has no live AWS/Neo4j credentials, so 503
+        # is an expected, correct outcome here -- the contract under test
+        # is the response shape, not a specific dependency-health result.
+        assert response.status_code in (200, 503)
         data = response.json()
         assert "status" in data
         assert "environment" in data
         assert "version" in data
+
+    def test_readiness_check(self, test_client):
+        """Test the deploy/rollback readiness probe"""
+        response = test_client.get("/ready")
+        # Postgres and Redis are real service containers in this test
+        # environment, so /ready (which checks only those two) should be
+        # genuinely ready.
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ready"
+        assert "checks" in data
+        assert set(data["checks"].keys()) == {"database", "redis"}
 
     def test_detailed_health_check(self, test_client):
         """Test detailed health check"""


### PR DESCRIPTION
## Summary
Critical finding #1 from the launch-readiness audit: `/ready` (the deploy/rollback/smoke-test promotion gate, and Docker's own `--health-cmd` target polled every 5s) unconditionally returned `200 {"status": "ready"}` with zero dependency checks. `/health` did real checks via `HealthChecker.get_detailed_health()` but always returned HTTP 200 regardless of result, so `curl -f`-based gates couldn't detect failure either way. This is how the prior `/metrics` crash loop went two weeks without CI catching it.

- `/ready`: new `HealthChecker.get_liveness_core()` checks only database + redis (the two cheapest, most load-bearing deps), returns 503 when either is down. Deliberately excludes slower/external checks since Docker polls this every 5s for the container's entire lifetime.
- `/health`: returns 503 when a **core** dependency (database, redis, bedrock, neo4j, s3) is unhealthy; a peripheral-only failure (secrets_manager, jwt_blacklist, langfuse, posthog) still returns 200 as "degraded" so a third-party analytics blip doesn't block a deploy.
- Added `check_neo4j()` and `check_s3()` — both were core dependencies with no health check at all before this.

No workflow YAML changes — `deploy-production.yml`'s `probe_backend_container()` already reads Docker's health status and falls back to curling `/ready` directly; it just never had real signal to gate on.

## Test plan
- [x] `python3 -m py_compile` on both files
- [x] Exercised `get_liveness_core()` and `get_detailed_health()` directly — both gracefully report `unhealthy` (not a crash) when dependencies are unreachable, and correctly classify core vs. peripheral failures
- [ ] CI / required status checks
- [ ] After merge + deploy: confirm `/ready` returns 200 in production with real DB/Redis reachable, and that Docker reports the container `(healthy)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health checks for database, cache, Neo4j, and S3 connectivity.
  * Enhanced health responses with environment, version, component details, and overall status.
  * Added readiness checks that quickly verify core services.

* **Bug Fixes**
  * Health endpoints now return HTTP 503 when required services are unhealthy.
  * Health status now distinguishes between fully healthy, degraded, and unhealthy states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->