### PR TITLE
Add rate limiting to research, code, RAG, and websocket chat routes

### DIFF
--- a/backend/api/routes/code.py
+++ b/backend/api/routes/code.py
@@ -8,7 +8,7 @@ This module provides endpoints for:
 
 import logging
 import re
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 from typing import Literal, Optional, List
 import traceback
@@ -18,7 +18,8 @@ import subprocess
 import tempfile
 import os
 
-from ..dependencies import get_current_user, get_admin_session
+from ..dependencies import get_current_user, get_admin_session, get_rate_limiter_dep
+from backend.rate_limiter import limiter, PerUserRateLimiter
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +156,14 @@ class CodeChatResponse(BaseModel):
     response: str
 
 
+def _code_llm_model_id() -> str:
+    """Resolve the code LLM model id, overridable via CODE_LLM_MODEL_ID."""
+    return os.environ.get(
+        "CODE_LLM_MODEL_ID",
+        "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    )
+
+
 def _get_code_llm():
     """Get the code LLM instance using AWS Bedrock.
 
@@ -166,11 +175,7 @@ def _get_code_llm():
         from backend.bedrock_llm import BedrockLLM
         from backend.config import config
 
-        model_id = os.environ.get(
-            "CODE_LLM_MODEL_ID",
-            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-        )
-        return BedrockLLM(model_id=model_id, region=config.AWS_REGION)
+        return BedrockLLM(model_id=_code_llm_model_id(), region=config.AWS_REGION)
     except (ImportError, ValueError, RuntimeError):
         logger.exception("Failed to initialize Bedrock LLM")
         return None
@@ -454,11 +459,16 @@ async def execute_code(
 
 
 @router.post("/generate", response_model=CodeGenerateResponse)
+@limiter.limit("40/hour")
 async def generate_code(
-    request: CodeGenerateRequest,
+    request: Request,
+    payload: CodeGenerateRequest,
     user: dict = Depends(get_current_user),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Generate code from a natural language prompt."""
+    await rate_limiter.check_rate_limit(request, limit=20, window=3600, scope="code_generate")
+    await rate_limiter.check_model_rate_limit(request, _code_llm_model_id())
     llm = _get_code_llm()
     if not llm:
         raise HTTPException(
@@ -467,30 +477,35 @@ async def generate_code(
         )
 
     system_prompt = (
-        f"You are a helpful coding assistant. Write ONLY {request.language} code for the following request. "
+        f"You are a helpful coding assistant. Write ONLY {payload.language} code for the following request. "
         "Output ONLY the code in a single code block. "
         "Do NOT include explanations, comments, or any text before or after the code block."
     )
 
     try:
         response = llm.generate(
-            prompt=f"Request: {request.prompt}\n\nCode:",
+            prompt=f"Request: {payload.prompt}\n\nCode:",
             system_prompt=system_prompt,
             max_tokens=2048,
             temperature=0.3,
         )
         code = _extract_code(response.strip())
-        return CodeGenerateResponse(code=code, language=request.language)
+        return CodeGenerateResponse(code=code, language=payload.language)
     except Exception as e:
         raise HTTPException(status_code=500, detail="Code generation failed")
 
 
 @router.post("/explain", response_model=CodeExplainResponse)
+@limiter.limit("40/hour")
 async def explain_code(
-    request: CodeExplainRequest,
+    request: Request,
+    payload: CodeExplainRequest,
     user: dict = Depends(get_current_user),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Explain what the code does."""
+    await rate_limiter.check_rate_limit(request, limit=20, window=3600, scope="code_explain")
+    await rate_limiter.check_model_rate_limit(request, _code_llm_model_id())
     llm = _get_code_llm()
     if not llm:
         raise HTTPException(
@@ -499,13 +514,13 @@ async def explain_code(
         )
 
     system_prompt = (
-        f"You are an expert {request.language} developer. "
+        f"You are an expert {payload.language} developer. "
         "Explain what the following code does, step by step, in simple terms."
     )
 
     try:
         response = llm.generate(
-            prompt=f"Code:\n{request.code}\n\nExplanation:",
+            prompt=f"Code:\n{payload.code}\n\nExplanation:",
             system_prompt=system_prompt,
             max_tokens=2048,
             temperature=0.3,
@@ -519,11 +534,16 @@ async def explain_code(
 
 
 @router.post("/debug", response_model=CodeDebugResponse)
+@limiter.limit("40/hour")
 async def debug_code(
-    request: CodeDebugRequest,
+    request: Request,
+    payload: CodeDebugRequest,
     user: dict = Depends(get_current_user),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Debug and fix code issues using AWS Bedrock."""
+    await rate_limiter.check_rate_limit(request, limit=20, window=3600, scope="code_debug")
+    await rate_limiter.check_model_rate_limit(request, _code_llm_model_id())
     llm = _get_code_llm()
     if not llm:
         raise HTTPException(
@@ -532,14 +552,14 @@ async def debug_code(
         )
 
     system_prompt = (
-        f"You are a skilled {request.language} developer. "
+        f"You are a skilled {payload.language} developer. "
         "Find and fix any bugs in the following code. "
         "Explain the problem and provide the corrected code."
     )
 
     try:
         response = llm.generate(
-            prompt=f"Code:\n{request.code}\n\nDebugging:",
+            prompt=f"Code:\n{payload.code}\n\nDebugging:",
             system_prompt=system_prompt,
             max_tokens=2048,
             temperature=0.3,
@@ -568,11 +588,16 @@ async def debug_code(
 
 
 @router.post("/chat", response_model=CodeChatResponse)
+@limiter.limit("60/hour")
 async def chat_with_code_llm(
-    request: CodeChatRequest,
+    request: Request,
+    payload: CodeChatRequest,
     user: dict = Depends(get_current_user),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Chat with AWS Bedrock for coding assistance."""
+    await rate_limiter.check_rate_limit(request, limit=30, window=3600, scope="code_chat")
+    await rate_limiter.check_model_rate_limit(request, _code_llm_model_id())
     llm = _get_code_llm()
     if not llm:
         raise HTTPException(
@@ -581,8 +606,8 @@ async def chat_with_code_llm(
         )
 
     context = ""
-    if request.history:
-        for msg in request.history[-5:]:
+    if payload.history:
+        for msg in payload.history[-5:]:
             role = msg.get("role", "user")
             content = msg.get("content", "")
             context += f"{role.capitalize()}: {content}\n"
@@ -597,7 +622,7 @@ async def chat_with_code_llm(
 
     try:
         response = llm.generate(
-            prompt=f"{context}User: {request.message}\nAssistant:",
+            prompt=f"{context}User: {payload.message}\nAssistant:",
             system_prompt=system_prompt,
             max_tokens=2048,
             temperature=0.7,

--- a/backend/api/routes/rag.py
+++ b/backend/api/routes/rag.py
@@ -2,7 +2,7 @@
 FastAPI routes for enhanced RAG service.
 """
 
-from fastapi import APIRouter, HTTPException, Depends, Header
+from fastapi import APIRouter, HTTPException, Depends, Header, Request
 from pydantic import BaseModel, Field
 from typing import Optional, List, Dict, Any
 import logging
@@ -10,7 +10,9 @@ import logging
 from backend.rag.service import RAGService, RAGVariant
 # Consolidated auth: supports both HttpOnly cookie (web clients) and Bearer
 # header (server-to-server). Also enforces disabled-user check.
-from backend.api.dependencies import get_current_user
+from backend.api.dependencies import get_current_user, get_rate_limiter_dep
+from backend.config import config
+from backend.rate_limiter import limiter, PerUserRateLimiter
 
 
 logger = logging.getLogger(__name__)
@@ -82,10 +84,13 @@ class RAGStatsResponse(BaseModel):
 # Routes
 
 @router.post("/query", response_model=RAGQueryResponse)
+@limiter.limit("60/hour")
 async def rag_query(
-    request: RAGQueryRequest,
+    request: Request,
+    payload: RAGQueryRequest,
     current_user: Dict[str, Any] = Depends(get_current_user),
-    rag_service: RAGService = Depends(get_rag_service)
+    rag_service: RAGService = Depends(get_rag_service),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """
     Process a RAG query with enhanced retrieval.
@@ -107,18 +112,20 @@ async def rag_query(
     }
     ```
     """
+    await rate_limiter.check_rate_limit(request, limit=30, window=3600, scope="rag_query")
+    await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
     try:
         user_id = current_user.get("sub")  # User ID from JWT
 
         result = await rag_service.query(
-            query=request.query,
+            query=payload.query,
             user_id=user_id,
-            variant=request.variant,
-            top_k=request.top_k,
-            max_retrieval=request.max_retrieval
+            variant=payload.variant,
+            top_k=payload.top_k,
+            max_retrieval=payload.max_retrieval
         )
 
-        logger.info(f"RAG query processed for user {user_id}: {request.query[:50]}...")
+        logger.info(f"RAG query processed for user {user_id}: {payload.query[:50]}...")
 
         return RAGQueryResponse(**result)
 
@@ -128,10 +135,13 @@ async def rag_query(
 
 
 @router.post("/ingest", response_model=DocumentIngestionResponse)
+@limiter.limit("30/hour")
 async def ingest_document(
-    request: DocumentIngestionRequest,
+    request: Request,
+    payload: DocumentIngestionRequest,
     current_user: Dict[str, Any] = Depends(get_current_user),
-    rag_service: RAGService = Depends(get_rag_service)
+    rag_service: RAGService = Depends(get_rag_service),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """
     Ingest a document into the RAG system.
@@ -154,14 +164,15 @@ async def ingest_document(
     }
     ```
     """
+    await rate_limiter.check_rate_limit(request, limit=15, window=3600, scope="rag_ingest")
     try:
         # Add user info to metadata
-        metadata = request.metadata.copy()
+        metadata = payload.metadata.copy()
         metadata["uploaded_by"] = current_user.get("email")
         metadata["user_id"] = current_user.get("sub")
 
         result = await rag_service.ingest_document(
-            content=request.content,
+            content=payload.content,
             metadata=metadata
         )
 

--- a/backend/api/routes/research.py
+++ b/backend/api/routes/research.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import logging
 from typing import List, Optional, TYPE_CHECKING
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, status
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File, status
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
-from backend.api.dependencies import get_current_session
+from backend.api.dependencies import get_current_session, get_rate_limiter_dep
+from backend.config import config
+from backend.rate_limiter import limiter, PerUserRateLimiter
 from backend.validators import FileValidator
 from backend.exceptions import InvalidFileError
 
@@ -142,11 +144,16 @@ def knowledge_base_stats(session=Depends(get_current_session)):
 
 
 @router.post("/query")
-def run_research_query(
+@limiter.limit("60/hour")
+async def run_research_query(
+    request: Request,
     payload: ResearchQueryRequest,
     session=Depends(get_current_session),
     service: ResearchService = Depends(get_research_service),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
+    await rate_limiter.check_rate_limit(request, limit=30, window=3600, scope="research_query")
+    await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
     if not payload.query.strip():
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -255,12 +262,16 @@ def clear_research_uploads_post(
 
 
 @router.post("/search/web")
-def search_web(
+@limiter.limit("40/hour")
+async def search_web(
+    request: Request,
     payload: WebSearchRequest,
     session=Depends(get_current_session),
     service: ResearchService = Depends(get_research_service),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Search the web for supplementary information."""
+    await rate_limiter.check_rate_limit(request, limit=20, window=3600, scope="research_search_web")
     try:
         result = service.search_web(payload.query, payload.max_results)
         return result
@@ -272,12 +283,16 @@ def search_web(
 
 
 @router.post("/search/academic")
-def search_academic(
+@limiter.limit("40/hour")
+async def search_academic(
+    request: Request,
     payload: AcademicSearchRequest,
     session=Depends(get_current_session),
     service: ResearchService = Depends(get_research_service),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Search academic databases (arXiv, PubMed, Google Scholar) for papers."""
+    await rate_limiter.check_rate_limit(request, limit=20, window=3600, scope="research_search_academic")
     try:
         result = service.search_academic_papers(
             payload.query, payload.sources, payload.max_results
@@ -291,12 +306,17 @@ def search_academic(
 
 
 @router.post("/compare")
-def compare_sources(
+@limiter.limit("30/hour")
+async def compare_sources(
+    request: Request,
     payload: CompareSourcesRequest,
     session=Depends(get_current_session),
     service: ResearchService = Depends(get_research_service),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Compare information across multiple documents on a topic."""
+    await rate_limiter.check_rate_limit(request, limit=15, window=3600, scope="research_compare")
+    await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
     try:
         result = service.compare_sources(
             payload.topic, payload.document_ids, payload.uploaded_only
@@ -310,12 +330,17 @@ def compare_sources(
 
 
 @router.post("/citations")
-def extract_citations(
+@limiter.limit("40/hour")
+async def extract_citations(
+    request: Request,
     payload: CitationExtractionRequest,
     session=Depends(get_current_session),
     service: ResearchService = Depends(get_research_service),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Extract and format citations from uploaded documents."""
+    await rate_limiter.check_rate_limit(request, limit=20, window=3600, scope="research_citations")
+    await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
     try:
         result = service.extract_citations(payload.document_id, payload.format_style)
         return result
@@ -327,12 +352,17 @@ def extract_citations(
 
 
 @router.post("/summary")
-def generate_summary(
+@limiter.limit("30/hour")
+async def generate_summary(
+    request: Request,
     payload: SummaryRequest,
     session=Depends(get_current_session),
     service: ResearchService = Depends(get_research_service),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Generate document summary in specified mode (executive, detailed, bullets)."""
+    await rate_limiter.check_rate_limit(request, limit=15, window=3600, scope="research_summary")
+    await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
     try:
         result = service.generate_summary(
             payload.document_id, payload.mode, payload.max_length
@@ -346,12 +376,17 @@ def generate_summary(
 
 
 @router.post("/questions")
-def generate_questions(
+@limiter.limit("30/hour")
+async def generate_questions(
+    request: Request,
     payload: QuestionGenerationRequest,
     session=Depends(get_current_session),
     service: ResearchService = Depends(get_research_service),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Generate study questions from uploaded documents."""
+    await rate_limiter.check_rate_limit(request, limit=15, window=3600, scope="research_questions")
+    await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
     try:
         result = service.generate_questions(
             payload.document_id,
@@ -368,12 +403,17 @@ def generate_questions(
 
 
 @router.post("/fact-check")
-def fact_check(
+@limiter.limit("30/hour")
+async def fact_check(
+    request: Request,
     payload: FactCheckRequest,
     session=Depends(get_current_session),
     service: ResearchService = Depends(get_research_service),
+    rate_limiter: PerUserRateLimiter = Depends(get_rate_limiter_dep),
 ):
     """Cross-reference claims across sources and provide a verdict."""
+    await rate_limiter.check_rate_limit(request, limit=15, window=3600, scope="research_fact_check")
+    await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
     try:
         result = service.fact_check(
             payload.claim, payload.uploaded_only, payload.include_web

--- a/backend/api/routes/ws_chat.py
+++ b/backend/api/routes/ws_chat.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect, HTTPException
 from backend.websocket.manager import manager
 from backend.services.models import ChatMessage
 from backend.logger import get_logger
+from backend.rate_limiter import get_rate_limiter
 import json
 import asyncio
 
@@ -111,6 +112,35 @@ async def websocket_chat_endpoint(
                         await websocket.send_json({
                             "type": "error",
                             "message": "Empty message"
+                        })
+                        continue
+
+                    # Rate limit each message the same way the HTTP /chat
+                    # route does -- an open WebSocket has no per-request
+                    # gate otherwise, so a tight client loop could fire
+                    # unlimited Bedrock calls for the life of the connection.
+                    try:
+                        rate_limiter = get_rate_limiter()
+                        await rate_limiter.check_rate_limit(
+                            websocket, limit=60, window=3600, scope="ws_chat_message"
+                        )
+                        from backend.config import config as app_config
+                        if app_config.LLM_ROUTING_ENABLED:
+                            from backend.llm_router import (
+                                classify_query_complexity,
+                                select_model_for_complexity,
+                            )
+                            tier, _ = classify_query_complexity(query)
+                            effective_model = select_model_for_complexity(tier)
+                        else:
+                            effective_model = app_config.BEDROCK_MODEL_ID
+                        await rate_limiter.check_model_rate_limit(websocket, effective_model)
+                    except HTTPException as exc:
+                        await websocket.send_json({
+                            "type": "error",
+                            "message": exc.detail.get("message", "Rate limit exceeded")
+                            if isinstance(exc.detail, dict) else str(exc.detail),
+                            "retry_after": exc.detail.get("retry_after") if isinstance(exc.detail, dict) else None,
                         })
                         continue
 

--- a/backend/rate_limiter.py
+++ b/backend/rate_limiter.py
@@ -185,7 +185,15 @@ class PerUserRateLimiter:
         window_secs = window or self.window_seconds
 
         # Get endpoint identifier
-        endpoint = f"{request.method}:{request.url.path}"
+        # WebSocket connections (e.g. ws_chat.py) share Request's .headers/
+        # .cookies/.url via the common HTTPConnection base class, but have
+        # no .method. .url.path also isn't usable there since it embeds a
+        # per-connection session_id -- keying on it would let a user bypass
+        # the limit by opening a new session per burst. Collapse to a
+        # literal "WS" identifier instead, so callers from that context
+        # rely solely on the caller-supplied `scope` to differentiate.
+        method = getattr(request, "method", None)
+        endpoint = f"{method}:{request.url.path}" if method else "WS"
 
         # Generate rate limit key
         key = self._get_rate_limit_key(username, endpoint, scope=scope)
@@ -236,7 +244,15 @@ class PerUserRateLimiter:
         if not username:
             return {"enabled": True, "authenticated": False}
 
-        endpoint = f"{request.method}:{request.url.path}"
+        # WebSocket connections (e.g. ws_chat.py) share Request's .headers/
+        # .cookies/.url via the common HTTPConnection base class, but have
+        # no .method. .url.path also isn't usable there since it embeds a
+        # per-connection session_id -- keying on it would let a user bypass
+        # the limit by opening a new session per burst. Collapse to a
+        # literal "WS" identifier instead, so callers from that context
+        # rely solely on the caller-supplied `scope` to differentiate.
+        method = getattr(request, "method", None)
+        endpoint = f"{method}:{request.url.path}" if method else "WS"
         key = self._get_rate_limit_key(username, endpoint)
 
         try:


### PR DESCRIPTION
## Summary
Critical finding #2 from the launch-readiness audit: `research.py` (7 endpoints), `code.py` (4 endpoints), `rag.py` (2 endpoints), and the entire `ws_chat.py` websocket handler had zero rate limiting — any authenticated user could script unlimited Bedrock calls through these paths. `chat.py` and `quiz.py` already established the right pattern (slowapi IP-level decorator + `PerUserRateLimiter` for per-user count and per-model-tier limits); this applies it consistently everywhere else that reaches an LLM.

- **research.py**: rate-limited all 8 LLM/search-backed endpoints (added `/citations` alongside the audit's original 7 — it uses `BedrockLLM` identically to the others, leaving it out would've been an arbitrary gap). Model-tier limiting only where Bedrock is actually called (not the two pure external-search endpoints).
- **code.py**: rate-limited all 4 endpoints. Had to rename each handler's body parameter from `request` to `payload` — slowapi's `@limiter.limit()` requires a parameter literally named `request`/`websocket` to find the `Request` object, which collided with the existing naming. Also makes the file consistent with `research.py`/`quiz.py`.
- **rag.py**: same treatment for `/query` and `/ingest`, even though this router is currently unmounted (separate pre-existing `RAGService` bug, tracked as its own finding) — protected by default whenever someone wires it up.
- **ws_chat.py**: per-message check inside the main loop, mirroring `chat.py`'s HTTP-path model resolution. Required a small `rate_limiter.py` fix since `check_rate_limit()` built its Redis key from `request.method`, which `WebSocket` objects don't have — collapsed to a stable `"WS"` identifier in that case (not `request.url.path`, which embeds a per-connection `session_id` and would let a user bypass the limit by opening a new session per burst).

## Test plan
- [x] `python3 -m py_compile` on all 5 files
- [x] Imported all 5 modules against the project's venv (which has the real dependency set) — 4 imported cleanly with zero errors; `rag.py`'s failure is the pre-existing, already-diagnosed `spacy`/`RAGService` dead-code chain, unrelated to this change
- [ ] CI / required status checks
- [ ] After merge: confirm a scripted burst against `/research/query` or `/code/chat` gets a 429 after the configured limit