### PR TITLE
Enforce a per-user daily Bedrock spend cap

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -310,6 +310,7 @@ async def send_message(
     else:
         effective_model = app_config.BEDROCK_MODEL_ID
     await rate_limiter.check_model_rate_limit(request, effective_model)
+    await rate_limiter.check_cost_budget(request, effective_model)
 
     # Resolve the generator before opening the stream — this lets FastAPI return
     # a proper 503 JSON body if the circuit is open or the LLM is unavailable,

--- a/backend/api/routes/code.py
+++ b/backend/api/routes/code.py
@@ -469,6 +469,7 @@ async def generate_code(
     """Generate code from a natural language prompt."""
     await rate_limiter.check_rate_limit(request, limit=20, window=3600, scope="code_generate")
     await rate_limiter.check_model_rate_limit(request, _code_llm_model_id())
+    await rate_limiter.check_cost_budget(request, _code_llm_model_id())
     llm = _get_code_llm()
     if not llm:
         raise HTTPException(
@@ -506,6 +507,7 @@ async def explain_code(
     """Explain what the code does."""
     await rate_limiter.check_rate_limit(request, limit=20, window=3600, scope="code_explain")
     await rate_limiter.check_model_rate_limit(request, _code_llm_model_id())
+    await rate_limiter.check_cost_budget(request, _code_llm_model_id())
     llm = _get_code_llm()
     if not llm:
         raise HTTPException(
@@ -544,6 +546,7 @@ async def debug_code(
     """Debug and fix code issues using AWS Bedrock."""
     await rate_limiter.check_rate_limit(request, limit=20, window=3600, scope="code_debug")
     await rate_limiter.check_model_rate_limit(request, _code_llm_model_id())
+    await rate_limiter.check_cost_budget(request, _code_llm_model_id())
     llm = _get_code_llm()
     if not llm:
         raise HTTPException(
@@ -598,6 +601,7 @@ async def chat_with_code_llm(
     """Chat with AWS Bedrock for coding assistance."""
     await rate_limiter.check_rate_limit(request, limit=30, window=3600, scope="code_chat")
     await rate_limiter.check_model_rate_limit(request, _code_llm_model_id())
+    await rate_limiter.check_cost_budget(request, _code_llm_model_id())
     llm = _get_code_llm()
     if not llm:
         raise HTTPException(

--- a/backend/api/routes/quiz.py
+++ b/backend/api/routes/quiz.py
@@ -61,6 +61,7 @@ async def generate_quiz(
         scope="quiz_generate",
     )
     await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
+    await rate_limiter.check_cost_budget(request, config.BEDROCK_MODEL_ID)
     _, user = session
     try:
         quiz = quiz_service.generate_quiz(

--- a/backend/api/routes/rag.py
+++ b/backend/api/routes/rag.py
@@ -114,6 +114,7 @@ async def rag_query(
     """
     await rate_limiter.check_rate_limit(request, limit=30, window=3600, scope="rag_query")
     await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
+    await rate_limiter.check_cost_budget(request, config.BEDROCK_MODEL_ID)
     try:
         user_id = current_user.get("sub")  # User ID from JWT
 

--- a/backend/api/routes/research.py
+++ b/backend/api/routes/research.py
@@ -154,6 +154,7 @@ async def run_research_query(
 ):
     await rate_limiter.check_rate_limit(request, limit=30, window=3600, scope="research_query")
     await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
+    await rate_limiter.check_cost_budget(request, config.BEDROCK_MODEL_ID)
     if not payload.query.strip():
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -317,6 +318,7 @@ async def compare_sources(
     """Compare information across multiple documents on a topic."""
     await rate_limiter.check_rate_limit(request, limit=15, window=3600, scope="research_compare")
     await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
+    await rate_limiter.check_cost_budget(request, config.BEDROCK_MODEL_ID)
     try:
         result = service.compare_sources(
             payload.topic, payload.document_ids, payload.uploaded_only
@@ -341,6 +343,7 @@ async def extract_citations(
     """Extract and format citations from uploaded documents."""
     await rate_limiter.check_rate_limit(request, limit=20, window=3600, scope="research_citations")
     await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
+    await rate_limiter.check_cost_budget(request, config.BEDROCK_MODEL_ID)
     try:
         result = service.extract_citations(payload.document_id, payload.format_style)
         return result
@@ -363,6 +366,7 @@ async def generate_summary(
     """Generate document summary in specified mode (executive, detailed, bullets)."""
     await rate_limiter.check_rate_limit(request, limit=15, window=3600, scope="research_summary")
     await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
+    await rate_limiter.check_cost_budget(request, config.BEDROCK_MODEL_ID)
     try:
         result = service.generate_summary(
             payload.document_id, payload.mode, payload.max_length
@@ -387,6 +391,7 @@ async def generate_questions(
     """Generate study questions from uploaded documents."""
     await rate_limiter.check_rate_limit(request, limit=15, window=3600, scope="research_questions")
     await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
+    await rate_limiter.check_cost_budget(request, config.BEDROCK_MODEL_ID)
     try:
         result = service.generate_questions(
             payload.document_id,
@@ -414,6 +419,7 @@ async def fact_check(
     """Cross-reference claims across sources and provide a verdict."""
     await rate_limiter.check_rate_limit(request, limit=15, window=3600, scope="research_fact_check")
     await rate_limiter.check_model_rate_limit(request, config.BEDROCK_MODEL_ID)
+    await rate_limiter.check_cost_budget(request, config.BEDROCK_MODEL_ID)
     try:
         result = service.fact_check(
             payload.claim, payload.uploaded_only, payload.include_web

--- a/backend/api/routes/ws_chat.py
+++ b/backend/api/routes/ws_chat.py
@@ -135,6 +135,7 @@ async def websocket_chat_endpoint(
                         else:
                             effective_model = app_config.BEDROCK_MODEL_ID
                         await rate_limiter.check_model_rate_limit(websocket, effective_model)
+                        await rate_limiter.check_cost_budget(websocket, effective_model)
                     except HTTPException as exc:
                         await websocket.send_json({
                             "type": "error",

--- a/backend/config.py
+++ b/backend/config.py
@@ -528,6 +528,12 @@ class Config:
     MODEL_RATE_LIMIT_ADMIN = int(os.getenv("MODEL_RATE_LIMIT_ADMIN", "5"))
     MODEL_RATE_LIMIT_WINDOW = int(os.getenv("MODEL_RATE_LIMIT_WINDOW", "3600"))  # 1 hour
 
+    # Per-user daily Bedrock spend cap in USD. Request-count limits above
+    # bound *how often* a user can call the LLM, but not how much a single
+    # burst can cost -- this bounds actual dollars. 0 disables enforcement.
+    # Resets at UTC midnight (see rate_limiter.py's check_cost_budget).
+    DAILY_COST_BUDGET_USD = float(os.getenv("DAILY_COST_BUDGET_USD", "2.00"))
+
     # Max concurrent LLM synthesis calls — backpressure for streaming chat
     LLM_MAX_CONCURRENT = int(os.getenv("LLM_MAX_CONCURRENT", "10"))
 

--- a/backend/rate_limiter.py
+++ b/backend/rate_limiter.py
@@ -4,7 +4,7 @@ Implements rate limiting based on authenticated user (not just IP address)
 Uses Redis for distributed rate limiting across multiple servers
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from fastapi import Request, HTTPException, status
 from slowapi import Limiter
@@ -28,6 +28,7 @@ limiter = Limiter(key_func=get_remote_address, enabled=_slowapi_enabled)
 MODEL_FAMILY_MAP = {
     "llama": "default",
     "claude-3-haiku": "fast",
+    "claude-haiku": "fast",  # covers claude-haiku-4-5 and later, not just claude-3-haiku
     "claude-3-5-sonnet": "pro",
     "claude-sonnet": "pro",
     "claude-opus": "admin",
@@ -56,6 +57,26 @@ def get_model_limit(family: str) -> int:
     return limits.get(family, config.MODEL_RATE_LIMIT_DEFAULT)
 
 
+# Conservative per-request cost estimate by family, in integer micro-dollars
+# (millionths of a USD -- Redis HINCRBY requires integers, and cents alone
+# would lose precision on the cheapest tier). Used only to enforce the daily
+# spend cap (see check_cost_budget). Derived from BedrockLLM.PRICING's
+# *output* rate (the pricier component) at an assumed ~2000 generated
+# tokens -- a request-time estimate, not exact billing; actual cost per
+# call is logged precisely post-call by cost_tracking.py.
+MODEL_FAMILY_COST_MICROS = {
+    "default": 2_000,     # Llama: ~$0.002/2K output tokens
+    "fast": 10_000,        # Haiku: ~$0.01/2K output tokens
+    "pro": 30_000,         # Sonnet: ~$0.03/2K output tokens
+    "admin": 150_000,      # Opus: ~$0.15/2K output tokens
+}
+
+
+def get_model_cost_estimate_micros(family: str) -> int:
+    """Conservative flat per-request cost estimate for a model family, in micro-dollars."""
+    return MODEL_FAMILY_COST_MICROS.get(family, MODEL_FAMILY_COST_MICROS["default"])
+
+
 class PerUserRateLimiter:
     """Rate limiter that tracks requests per authenticated user"""
 
@@ -74,6 +95,25 @@ class PerUserRateLimiter:
     end
     
     return current_count
+    """
+
+    # Lua script for atomic per-user daily spend tracking. Same
+    # increment-then-compare shape as _RATE_LIMIT_LUA_SCRIPT: the request
+    # that pushes the total over budget is the one rejected by the caller,
+    # but its estimated cost is still recorded (consistent with how the
+    # request-count limiter already behaves).
+    _BUDGET_LUA_SCRIPT = """
+    local key = KEYS[1]
+    local ttl_secs = ARGV[1]
+    local increment_micros = ARGV[2]
+
+    local current_micros = redis.call('hincrby', key, 'micros', increment_micros)
+
+    if current_micros == tonumber(increment_micros) then
+        redis.call('expire', key, ttl_secs)
+    end
+
+    return current_micros
     """
 
     def __init__(self, redis_cache: Optional[RedisCache] = None):
@@ -321,6 +361,70 @@ class PerUserRateLimiter:
             raise
         except Exception as e:
             logger.warning(f"Model rate limiter error: {e}")
+
+    async def check_cost_budget(self, request: Request, model_id: str) -> None:
+        """
+        Enforce a per-user daily USD spend cap across all Bedrock calls.
+
+        Request-count limits (check_rate_limit, check_model_rate_limit)
+        bound how *often* a user can call the LLM, but not how much a
+        single burst of expensive requests can cost -- this bounds actual
+        dollars. Uses a conservative flat per-request estimate by model
+        family (see MODEL_FAMILY_COST_MICROS) rather than exact post-call
+        cost, since the real token count isn't known until the LLM
+        response completes; exact per-call cost is still logged separately
+        and precisely by cost_tracking.py for billing/audit purposes.
+
+        The tracking key is suffixed with today's UTC date, so it resets
+        naturally at midnight rather than N hours after each user's first
+        request of the day.
+        """
+        if not self.enabled:
+            return
+
+        budget_usd = config.DAILY_COST_BUDGET_USD
+        if budget_usd <= 0:
+            return  # Budget enforcement disabled
+
+        username = self._get_username_from_token(request)
+        if not username:
+            return
+
+        family = get_model_family(model_id)
+        increment_micros = get_model_cost_estimate_micros(family)
+        budget_micros = int(budget_usd * 1_000_000)
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        key = f"cost_budget:user:{username}:{today}"
+
+        try:
+            redis_client = self.redis.client
+            # 90000s (25h) TTL as a safety net so the key doesn't linger
+            # indefinitely if Redis somehow never expires it -- the daily
+            # date suffix is what actually drives the reset boundary.
+            current_micros = redis_client.eval(
+                self._BUDGET_LUA_SCRIPT, 1, key, 90000, increment_micros
+            )
+
+            if current_micros > budget_micros:
+                spent_usd = current_micros / 1_000_000
+                logger.warning(
+                    f"Daily cost budget exceeded for {username}: ~${spent_usd:.4f}/${budget_usd:.2f}"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail={
+                        "error": "Daily spend limit reached",
+                        "message": (
+                            f"You've reached today's usage limit (${budget_usd:.2f}). "
+                            "It resets at midnight UTC."
+                        ),
+                        "budget_usd": budget_usd,
+                    },
+                )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning(f"Cost budget check error: {e}")
 
     async def get_all_model_limits(self, request: Request) -> dict:
         """Return rate-limit status for every model family for this user."""


### PR DESCRIPTION
## Summary
Critical finding #3 from the launch-readiness audit: `cost_tracking.py` logs every LLM call's cost but never consults that data before allowing another call — no budget config existed anywhere. The request-count rate limits added for finding #2 (#44) bound how *often* a user can call an LLM, but not how many dollars a burst of expensive requests can cost.

- Added `PerUserRateLimiter.check_cost_budget()`, enforcing a new `DAILY_COST_BUDGET_USD` config (default $2.00/user/day, `0` disables it).
- Uses a conservative flat per-request cost estimate by model family (derived from `BedrockLLM.PRICING`'s output rate at ~2000 tokens) rather than exact post-call cost, since real token counts aren't known until the response completes — intentionally errs toward overcounting for a safety cap, not billing precision.
- Redis-backed atomic counter keyed by user+UTC-date (same pattern as the existing rate-limit Lua script), so it resets at midnight rather than N hours after a user's first request.
- Wired in alongside `check_model_rate_limit()` at all 14 existing call sites (chat.py, quiz.py, research.py ×6, code.py ×4, rag.py, ws_chat.py) — no new route-level plumbing needed beyond one line per site.
- Bonus fix found while building the cost table: `MODEL_FAMILY_MAP` only matched `"claude-3-haiku"`, so the newer `"claude-haiku-4-5"` model silently fell through to the cheapest "default" tier for both rate limiting and cost estimation. Added a version-agnostic `"claude-haiku"` pattern.

## Test plan
- [x] `python3 -m py_compile` on all 8 files
- [x] Imported all touched modules against the project venv — clean except `rag.py`'s pre-existing, already-diagnosed `spacy` issue (unrelated to this change)
- [x] Functionally tested `check_cost_budget` against a mocked Redis client: under-budget (no exception), over-budget (429 raised), and budget=0 (enforcement disabled) — caught and fixed a missing `timezone` import in the process
- [x] Confirmed the Haiku 4.5 family-mapping fix takes effect end-to-end (correctly resolves to the "fast" tier's cost estimate, not "default")
- [ ] CI / required status checks
- [ ] After merge: confirm a scripted burst of Opus-tier requests gets a 429 with "Daily spend limit reached" once the budget is hit