### PR TITLE
Scope the answer cache per user to close cross-user cache poisoning

### DIFF
--- a/backend/rag/caching_layer.py
+++ b/backend/rag/caching_layer.py
@@ -446,11 +446,21 @@ class QueryCache:
         self._fuzzy_dim = fuzzy_embedding_dim
         self._use_hnsw = use_hnsw
 
-    def _generate_key(self, query: str) -> str:
-        """Generate cache key from query"""
-        # Normalize query
+    def _generate_key(self, query: str, user_id: Optional[str] = None) -> str:
+        """Generate cache key from query, scoped per user.
+
+        Without user_id in the key, two different users asking the exact
+        same normalized text would share one cache entry -- a jailbroken
+        or incorrect answer elicited by one user would be replayed
+        verbatim to everyone else asking something textually identical,
+        for the full cache TTL. user_id defaults to None (not a real
+        empty-string user) so callers that genuinely have no identity
+        still get a single shared, clearly-unauthenticated bucket rather
+        than silently colliding with a real user's cache.
+        """
         normalized = query.lower().strip()
-        return hashlib.sha256(normalized.encode()).hexdigest()
+        scope = user_id or "__anonymous__"
+        return hashlib.sha256(f"{scope}:{normalized}".encode()).hexdigest()
 
     def _calculate_similarity(
         self,
@@ -472,12 +482,12 @@ class QueryCache:
 
         return dot_product / (norm1 * norm2)
 
-    def get_exact(self, query: str) -> Optional[Dict[str, Any]]:
-        """Get cached result for exact query match"""
+    def get_exact(self, query: str, user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
+        """Get cached result for exact query match, scoped to user_id"""
         if not self.use_exact_matching:
             return None
 
-        key = self._generate_key(query)
+        key = self._generate_key(query, user_id)
 
         # Check in-memory cache
         result = self.exact_cache.get(key)
@@ -502,13 +512,22 @@ class QueryCache:
     def get_fuzzy(
         self,
         query: str,
-        query_embedding: List[float]
+        query_embedding: List[float],
+        user_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Get cached result for similar query (fuzzy match).
+        """Get cached result for similar query (fuzzy match), scoped to user_id.
 
         Uses an HNSW (when available) or vectorised numpy index for $O(\\log N)$
         or BLAS-accelerated similarity lookup. Falls back to a miss on any
         index inconsistency rather than a Python loop scan.
+
+        The vector index itself is shared across all users' embeddings --
+        unlike the exact-match cache, folding user_id into the key alone
+        doesn't scope this, since nearest-neighbour search finds the
+        closest embedding regardless of whose query produced it. The
+        nearest match's stored user_id is checked explicitly instead; a
+        mismatch is treated as a miss rather than serving another user's
+        cached answer for a "close enough" question.
         """
         if not self.use_fuzzy_matching or self._fuzzy_index is None:
             return None
@@ -523,6 +542,9 @@ class QueryCache:
             self._fuzzy_index.remove(best_key)
             return None
 
+        if cached_data.get("user_id") != user_id:
+            return None
+
         logger.debug(
             f"Query cache HIT (fuzzy, similarity={best_similarity:.3f}): {query[:50]}"
         )
@@ -532,10 +554,11 @@ class QueryCache:
         self,
         query: str,
         result: Dict[str, Any],
-        query_embedding: Optional[List[float]] = None
+        query_embedding: Optional[List[float]] = None,
+        user_id: Optional[str] = None,
     ):
-        """Store query result in cache"""
-        key = self._generate_key(query)
+        """Store query result in cache, scoped to user_id"""
+        key = self._generate_key(query, user_id)
 
         # Store in exact cache
         if self.use_exact_matching:
@@ -577,16 +600,17 @@ class QueryCache:
                 "query": query,
                 "embedding": query_embedding,
                 "result": result,
+                "user_id": user_id,
             })
             if evicted_key:
                 self._fuzzy_index.remove(evicted_key)
             self._fuzzy_index.add(key, query_embedding)
 
-    def invalidate(self, query: Optional[str] = None):
+    def invalidate(self, query: Optional[str] = None, user_id: Optional[str] = None):
         """Invalidate cache entries"""
         if query:
             # Invalidate specific query
-            key = self._generate_key(query)
+            key = self._generate_key(query, user_id)
             if key in self.exact_cache.cache:
                 del self.exact_cache.cache[key]
 
@@ -671,17 +695,18 @@ class RAGCache:
     def get_query_result(
         self,
         query: str,
-        query_embedding: Optional[List[float]] = None
+        query_embedding: Optional[List[float]] = None,
+        user_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Get cached query result (exact or fuzzy match)"""
+        """Get cached query result (exact or fuzzy match), scoped to user_id"""
         # Try exact match first
-        result = self.query_cache.get_exact(query)
+        result = self.query_cache.get_exact(query, user_id)
         if result:
             return result
 
         # Try fuzzy match
         if query_embedding:
-            result = self.query_cache.get_fuzzy(query, query_embedding)
+            result = self.query_cache.get_fuzzy(query, query_embedding, user_id)
             if result:
                 return result
 
@@ -691,10 +716,11 @@ class RAGCache:
         self,
         query: str,
         result: Dict[str, Any],
-        query_embedding: Optional[List[float]] = None
+        query_embedding: Optional[List[float]] = None,
+        user_id: Optional[str] = None,
     ):
-        """Cache query result"""
-        self.query_cache.put(query, result, query_embedding)
+        """Cache query result, scoped to user_id"""
+        self.query_cache.put(query, result, query_embedding, user_id)
 
     def get_all_stats(self) -> Dict[str, Any]:
         """Get statistics for all caches"""

--- a/utils.py
+++ b/utils.py
@@ -709,17 +709,23 @@ def _self_rag_wrapper(generator, context_str: str):
         yield DISCLAIMER
 
 
-def _check_answer_cache(query: str) -> Optional[Dict]:
-    """Check exact then fuzzy cache. Returns {response, sources} or None."""
+def _check_answer_cache(query: str, user_id: Optional[str] = None) -> Optional[Dict]:
+    """Check exact then fuzzy cache, scoped to user_id. Returns {response, sources} or None.
+
+    user_id scoping matters: without it, one user's bad, incorrect, or
+    successfully-jailbroken answer would be replayed verbatim to every
+    other user asking the same (or, via fuzzy match, a similar-enough)
+    question for the rest of the cache TTL.
+    """
     try:
         cache = _get_answer_cache()
-        return cache.get_query_result(query)
+        return cache.get_query_result(query, user_id=user_id)
     except Exception as exc:
         logging.warning(f"Answer cache lookup failed: {exc}")
         return None
 
 
-def _caching_generator(original_gen, query, sources):
+def _caching_generator(original_gen, query, sources, user_id: Optional[str] = None):
     """Tee pattern: yield chunks to frontend AND collect for caching."""
     chunks = []
     for chunk in original_gen:
@@ -737,6 +743,7 @@ def _caching_generator(original_gen, query, sources):
                     "sources": sources,
                     "cached_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
                 },
+                user_id=user_id,
             )
             logging.info(f"Answer cached for query: {query[:60]}...")
         except Exception as exc:
@@ -838,7 +845,7 @@ def generate_response_stream_and_sources(
 
         # Answer Cache: check for cached response before RAG retrieval
         if config.ANSWER_CACHE_ENABLED:
-            cached = _check_answer_cache(query)
+            cached = _check_answer_cache(query, user_id=user_id)
             if cached:
                 logging.info(f"Answer cache HIT for: {query[:60]}...")
 
@@ -1071,10 +1078,14 @@ def generate_response_stream_and_sources(
                 response_text_generator, context_str
             )
 
-        # Answer Cache: wrap generator to cache the full response after streaming
-        if config.ANSWER_CACHE_ENABLED:
+        # Answer Cache: wrap generator to cache the full response after streaming.
+        # Skip web-search-derived answers -- they're time-sensitive and
+        # ungrounded-checked (see the Self-RAG skip above), so caching them
+        # for up to ANSWER_CACHE_TTL risks serving stale "current events"
+        # answers well past their freshness window.
+        if config.ANSWER_CACHE_ENABLED and not used_web_search:
             response_text_generator = _caching_generator(
-                response_text_generator, query, response_sources
+                response_text_generator, query, response_sources, user_id=user_id
             )
 
         context_passages = []


### PR DESCRIPTION
## Summary
Critical finding #6 from the launch-readiness audit: the answer cache keyed purely on normalized query text, with no per-user scoping. One user eliciting a bad, incorrect, or successfully-jailbroken answer would have it replayed verbatim to every other user asking the same — or, via fuzzy matching at cosine ≥0.95, a merely similar — question, for up to the cache TTL (1 hour default).

- Folded `user_id` into `QueryCache._generate_key`, so the exact-match cache is scoped per user.
- Threaded `user_id` through `get_exact`/`get_fuzzy`/`put`/`invalidate` and `RAGCache`'s public methods, down to `utils.py`'s `_check_answer_cache`/`_caching_generator` — which already had `user_id` in scope (an existing parameter of the enclosing function), it just wasn't being passed down.
- Fuzzy matching needed a second fix: the vector index is shared across all users' embeddings, so a similarity search finds the nearest embedding regardless of whose query produced it — folding `user_id` into the key alone doesn't scope a *search*. Added an explicit ownership check that treats a stored-`user_id` mismatch as a miss.
- Bonus: skip caching entirely for web-search-derived answers (directly adjacent gap in the same code path — these are time-sensitive and already skip the Self-RAG grounding check two lines above).

## Test plan
- [x] `python3 -m py_compile` on both files
- [x] `utils.py` imports cleanly via the project venv
- [x] **Functional cross-user isolation tests** (loading `caching_layer.py` standalone, bypassing an unrelated pre-existing `spacy` dependency gap in this test sandbox): confirmed a second user's exact-match lookup for the identical query returns a miss instead of the first user's cached answer; confirmed the same for a fuzzy/similar-but-not-identical query
- [ ] CI / required status checks