### PR TITLE
Stop Neo4j Aura resume from blocking the event loop for every user

### DIFF
--- a/backend/agents/neo4j_client.py
+++ b/backend/agents/neo4j_client.py
@@ -97,8 +97,23 @@ def _get_instance_status() -> Optional[str]:
         return None
 
 
-def _resume_aura_instance(max_wait: int = 120) -> bool:
-    """Resume a paused Aura instance and wait for it to become running.
+def _resume_aura_instance(max_wait: int = 20) -> bool:
+    """Trigger an Aura resume and do a brief best-effort check -- WITHOUT
+    blocking for anywhere near the full resume duration.
+
+    Real Aura resume takes 7-12 minutes (the dedicated Neo4j Aura Resume
+    Guard workflow's poll timeout was deliberately bumped to 900s after a
+    real run measured 420s) -- far longer than any request should ever
+    block for. The old 120s default couldn't succeed on a genuine cold
+    pause either, it just wasted two minutes finding that out. This
+    fires the resume request and polls briefly (default 20s) purely to
+    catch the fast case where the instance was already resuming when we
+    got here; on the much more common cold-pause case, callers get a
+    quick "not ready yet" and should degrade gracefully -- see
+    profile.py's _graph_profile, which already falls back to an empty
+    profile on any exception here -- rather than hang. Keeping the
+    instance warm in steady state is the scheduled resume-guard
+    workflow's job, not this in-request path's.
 
     Uses a lock to prevent multiple concurrent resume attempts.
     Returns True if the instance is running, False otherwise.

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -315,9 +315,19 @@ async def send_message(
     # Resolve the generator before opening the stream — this lets FastAPI return
     # a proper 503 JSON body if the circuit is open or the LLM is unavailable,
     # rather than sending a partial streamed response then aborting.
+    #
+    # stream_response() is synchronous and does real blocking work before it
+    # ever returns a generator -- student profile lookup (including a Neo4j
+    # call that can trip an Aura auto-resume attempt), RAG retrieval, and
+    # agent routing. Called directly inside this async handler with no
+    # await/to_thread, any one of those blocks the whole event loop, so
+    # every other concurrent request on this worker stalls too, not just
+    # this one. asyncio.to_thread moves it off the event loop so a slow
+    # or paused-Neo4j request only blocks its own thread-pool worker.
     from backend.circuit_breaker import CircuitBreakerOpenError, bedrock_circuit_breaker
     try:
-        generator, sources, resolved_model_id = chat_service.stream_response(
+        generator, sources, resolved_model_id = await asyncio.to_thread(
+            chat_service.stream_response,
             effective_query,
             user_id=user["username"],
             session_id=session_id,

--- a/backend/api/routes/ws_chat.py
+++ b/backend/api/routes/ws_chat.py
@@ -152,10 +152,18 @@ async def websocket_chat_endpoint(
 
                     # Stream response
                     try:
-                        generator, sources, _ = chat_service.stream_response(
+                        # stream_response() itself does real blocking work before
+                        # it returns a generator (profile lookup incl. a Neo4j
+                        # call that can trip an Aura auto-resume attempt, RAG
+                        # retrieval, agent routing) -- offload the call itself,
+                        # not just the generator iteration below, or a slow or
+                        # paused-Neo4j request blocks the whole event loop for
+                        # every other connection this worker is serving.
+                        generator, sources, _ = await asyncio.to_thread(
+                            chat_service.stream_response,
                             query,
                             user_id=user_id,
-                            session_id=session_id
+                            session_id=session_id,
                         )
 
                         # Collect chunks in a thread-pool worker so the sync generator


### PR DESCRIPTION
## Summary
Critical finding #7 from the launch-readiness audit: `chat.py`'s `send_message` and `ws_chat.py`'s message loop both called `chat_service.stream_response()` — which does real synchronous work (student profile lookup including a Neo4j call, RAG retrieval, agent routing) before it ever returns a generator — directly inside their `async def` handlers, with no `await`/`asyncio.to_thread`. One user hitting a paused Neo4j instance stalled every other concurrent request this worker was serving, not just their own.

Compounding it: `_resume_aura_instance`'s blocking poll loop waited up to 120s before giving up, but real Aura resume takes 7-12 minutes — so on an actual cold pause that 120s was never going to succeed, it just guaranteed the worst-case block was as long as possible for no benefit.

- `chat.py`/`ws_chat.py` now call `stream_response()` via `await asyncio.to_thread(...)`. A slow or paused-Neo4j request now only blocks its own thread-pool worker, not the shared event loop.
- `_resume_aura_instance`'s `max_wait` default dropped from 120s to 20s — not long enough to complete a real resume either, but that was already true at 120s. The scheduled Neo4j Aura Resume Guard workflow owns actually keeping the instance warm; this just stops wasting two minutes finding out a cold pause won't resolve in-request. `profile.py`'s `_graph_profile` already catches the exception and falls back to an empty profile, so callers degrade gracefully much faster now.

## Test plan
- [x] `python3 -m py_compile` + import validation (project venv) on all 3 files
- [x] **Functional test**: mocked an always-paused Aura instance — confirmed `_resume_aura_instance()` now bails at ~20s instead of 120s
- [x] **Functional test**: standalone `asyncio` test confirming a concurrent task's latency is unaffected by a slow `asyncio.to_thread` call running alongside it (validates the core mechanism the chat.py/ws_chat.py fix relies on)
- [ ] CI / required status checks