### PR TITLE
Revoke refresh tokens on logout and rotate them on every use

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -467,17 +467,10 @@ def refresh_token(
 
         tokens = auth_service.refresh_token(refresh_token_value)
 
-        # SECURITY: Set new access token in HttpOnly cookie
-        # Note: Refresh token stays the same
-        response.set_cookie(
-            key="access_token",
-            value=tokens["access_token"],
-            httponly=True,
-            secure=config.ENVIRONMENT == "production",
-            samesite="lax",
-            max_age=config.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-            path="/",
-        )
+        # SECURITY: Refresh tokens rotate on every use (single-use) — set_auth_cookies
+        # writes both the new access_token and the new refresh_token cookie, and
+        # matches the domain/secure/samesite attributes used at login.
+        set_auth_cookies(response, tokens["access_token"], tokens["refresh_token"])
 
         # Renew CSRF cookie so it doesn't expire while the user is still logged in
         from backend.csrf_protection import CSRFProtection
@@ -580,7 +573,11 @@ def logout(
     SECURITY: Removes HttpOnly cookies to prevent token reuse.
     """
     token, user = session
-    auth_service.logout(token)
+    # SECURITY: Also revoke the refresh token cookie, not just the access token,
+    # so a copied/stolen refresh_token cookie can't keep minting access tokens
+    # after the user has explicitly logged out.
+    refresh_token_value = request.cookies.get("refresh_token")
+    auth_service.logout(token, refresh_token_value)
 
     # SECURITY: Log logout
     SecurityLogger.log_logout(

--- a/backend/api/routes/profile.py
+++ b/backend/api/routes/profile.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING
 
@@ -102,6 +102,7 @@ def change_password(
 
 @router.delete("")
 def delete_account(
+    request: Request,
     payload: DeleteAccountPayload,
     session=Depends(get_current_session),
     service: ProfileService = Depends(get_profile_service),
@@ -118,7 +119,10 @@ def delete_account(
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
 
-    auth_service.logout(token)
+    # SECURITY: Revoke the refresh token too — the account no longer exists,
+    # so its refresh token must not be able to mint further access tokens.
+    refresh_token_value = request.cookies.get("refresh_token")
+    auth_service.logout(token, refresh_token_value)
     return {"success": True}
 
 

--- a/backend/auth_service.py
+++ b/backend/auth_service.py
@@ -750,29 +750,53 @@ class AuthService:
             refresh_token: Valid refresh token
 
         Returns:
-            New tokens dict with access_token and token_type
+            New tokens dict with access_token, refresh_token, and token_type
 
         Raises:
-            SessionExpiredError: If refresh token is invalid
+            SessionExpiredError: If refresh token is invalid or has been revoked
         """
         try:
+            # SECURITY: A refresh token blacklisted at logout (or by a prior
+            # rotation below) must not be usable to mint new access tokens.
+            if self.jwt_blacklist and self.jwt_blacklist.is_blacklisted(refresh_token):
+                raise SessionExpiredError("Refresh token has been revoked")
+
             # Verify refresh token and get new access token
             new_access_token = self.jwt_service.refresh_access_token(refresh_token)
+            payload = self.jwt_service.verify_token(refresh_token, token_type="refresh")
+
+            # SECURITY: Rotate the refresh token on every use (single-use refresh
+            # tokens) so a stolen-but-unused cookie stops working the moment the
+            # legitimate client refreshes, instead of staying valid for 7 days.
+            new_refresh_token = self.jwt_service.create_refresh_token(
+                username=payload.get("sub"), email=payload.get("email", "")
+            )
+            if self.jwt_blacklist:
+                exp = payload.get("exp")
+                if exp:
+                    expiry_seconds = max(int(exp - datetime.now().timestamp()), 0)
+                else:
+                    expiry_seconds = config.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600
+                self.jwt_blacklist.blacklist_token(refresh_token, expiry_seconds)
 
             logger.info("Access token refreshed successfully")
 
             return {
                 "access_token": new_access_token,
+                "refresh_token": new_refresh_token,
                 "token_type": "bearer"
             }
+        except SessionExpiredError:
+            raise
         except Exception as e:
             logger.warning(f"Token refresh failed: {e}")
             raise SessionExpiredError("Invalid refresh token")
 
-    def logout(self, session_token: str) -> None:
+    def logout(self, session_token: str, refresh_token: Optional[str] = None) -> None:
         """
         Logout and invalidate session.
-        Adds JWT token to blacklist to prevent further use.
+        Adds JWT access token (and, if provided, refresh token) to the blacklist
+        to prevent further use.
         """
         # Remove legacy sessions if they exist
         if session_token in self.sessions:
@@ -809,6 +833,26 @@ class AuthService:
             # Log error but don't fail the logout
             logger.error(f"Error during logout: {e}")
             logger.info("User logged out (token may not be blacklisted)")
+
+        # SECURITY: Also revoke the refresh token. Without this, a stolen refresh
+        # token cookie keeps minting new access tokens for its full 7-day life
+        # even after the legitimate user has explicitly logged out.
+        if refresh_token:
+            try:
+                refresh_payload = self.jwt_service.verify_token(refresh_token, token_type="refresh")
+                refresh_exp = refresh_payload.get("exp")
+                if refresh_exp:
+                    refresh_expiry_seconds = max(int(refresh_exp - datetime.now().timestamp()), 0)
+                else:
+                    refresh_expiry_seconds = config.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600
+
+                if self.jwt_blacklist:
+                    self.jwt_blacklist.blacklist_token(refresh_token, refresh_expiry_seconds)
+                    logger.info("Refresh token blacklisted at logout")
+            except SessionExpiredError:
+                logger.info("Refresh token already expired at logout")
+            except Exception as e:
+                logger.error(f"Error revoking refresh token during logout: {e}")
 
     def change_password(self, username: str, old_password: str, new_password: str) -> None:
         """

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -74,8 +74,8 @@ class AccountLockedError(AuthenticationError):
 
 class SessionExpiredError(AuthenticationError):
     """User session has expired"""
-    def __init__(self):
-        super().__init__("Session expired. Please log in again", "SESSION_EXPIRED")
+    def __init__(self, message: str = "Session expired. Please log in again"):
+        super().__init__(message, "SESSION_EXPIRED")
 
 
 class PasswordValidationError(AuthenticationError):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -272,3 +272,51 @@ class TestJWTSecurity:
         response = test_client.get("/auth/me", headers={"Authorization": f"Bearer {refresh_token}"})
         assert response.status_code == 200
         assert response.json().get("user") is None
+
+    def test_refresh_token_revoked_after_logout(self, test_client, test_user):
+        """A stolen refresh token must stop working the moment the user logs out,
+        not just when it eventually expires up to 7 days later."""
+        import re
+        test_client.cookies.clear()
+        login = test_client.post("/auth/login", json={
+            "username": test_user["username"],
+            "password": test_user["password"]
+        })
+        set_cookie = login.headers.get("set-cookie", "")
+        match = re.search(r"refresh_token=([^;]+)", set_cookie)
+        assert match, "No refresh_token found in login cookies"
+        refresh_token = match.group(1)
+
+        logout_response = test_client.post("/auth/logout")
+        assert logout_response.status_code == 200
+
+        # Replay the (now revoked) refresh token directly against /auth/refresh
+        test_client.cookies.clear()
+        response = test_client.post("/auth/refresh", cookies={"refresh_token": refresh_token})
+        assert response.status_code == 401
+
+        test_client.cookies.clear()
+
+    def test_refresh_token_rotates_and_old_one_is_rejected(self, test_client, test_user):
+        """Refresh tokens are single-use: once rotated, the pre-rotation token
+        must be rejected even though it hasn't expired yet."""
+        import re
+        test_client.cookies.clear()
+        login = test_client.post("/auth/login", json={
+            "username": test_user["username"],
+            "password": test_user["password"]
+        })
+        set_cookie = login.headers.get("set-cookie", "")
+        match = re.search(r"refresh_token=([^;]+)", set_cookie)
+        assert match, "No refresh_token found in login cookies"
+        old_refresh_token = match.group(1)
+
+        first_refresh = test_client.post("/auth/refresh")
+        assert first_refresh.status_code == 200
+
+        # Replaying the pre-rotation refresh token must now be rejected
+        test_client.cookies.clear()
+        replay = test_client.post("/auth/refresh", cookies={"refresh_token": old_refresh_token})
+        assert replay.status_code == 401
+
+        test_client.cookies.clear()


### PR DESCRIPTION
## Summary
- Closes the final critical launch-readiness finding: refresh tokens never rotated or got revoked on logout, leaving a stolen `refresh_token` cookie usable for its full 7-day lifetime even after explicit logout.
- `AuthService.refresh_token()` now checks the existing `JWTBlacklist` before minting a new access token, and rotates the refresh token on every use (old token blacklisted immediately) — single-use refresh tokens, reuse-detection included.
- `AuthService.logout()` now also revokes the refresh token (not just the access token), wired into both `/auth/logout` and the account-deletion flow in `profile.py`, which had the same gap.
- `/auth/refresh` now reuses `set_auth_cookies()` so the rotated refresh_token cookie actually gets written (previously only access_token was updated), which also fixes a missing `domain=` attribute on that cookie versus every other cookie-setting path.
- Fixed a pre-existing bug found while testing this: `SessionExpiredError(message)` didn't actually accept a message argument, so 8 existing call sites across `auth_service.py`/`jwt_service.py` that passed one were raising `TypeError` instead of the intended 401.

## Test plan
- [x] Standalone functional test against the real `AuthService`/`JWTService`/`JWTBlacklist` (no mocks): rotation produces a new refresh token, the old one is rejected, logout blacklists both access and refresh tokens, and an unrelated user's token is unaffected (no over-broad revocation).
- [x] Added `test_refresh_token_revoked_after_logout` and `test_refresh_token_rotates_and_old_one_is_rejected` to `backend/tests/test_auth.py`.
- [ ] CI: Backend Tests (full suite incl. new tests), SAST/CodeQL, Contract Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refresh tokens now rotate after each successful refresh.
  * Signing out and deleting an account revoke both access and refresh tokens.
  * Previously used or revoked refresh tokens are rejected.

* **Bug Fixes**
  * Authentication cookies are updated consistently during token refresh.

* **Tests**
  * Added coverage for refresh-token revocation and replay prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->