### PR TITLE
Fix /health S3 check bucket mismatch and align eval cron to maintenance window

### DIFF
--- a/.github/workflows/rag-evaluation-scheduled.yml
+++ b/.github/workflows/rag-evaluation-scheduled.yml
@@ -2,7 +2,11 @@ name: Scheduled RAG Evaluation
 
 on:
   schedule:
-    - cron: "0 6 * * *" # daily at 06:00 UTC
+    # 16:00 UTC = 11am CDT / 10am CST, Mon-Fri only — inside the 9AM-5PM
+    # Central maintenance window so this doesn't wake the cost-saving EC2
+    # instance outside its scheduled hours (it was previously "0 6 * * *",
+    # 1am Central every day including weekends).
+    - cron: "0 16 * * 1-5"
   workflow_dispatch:
     inputs:
       dataset_limit:

--- a/backend/health.py
+++ b/backend/health.py
@@ -154,20 +154,24 @@ class HealthChecker:
         try:
             from backend.config import config
 
-            if not config.S3_VECTORS_BUCKET:
+            # S3_DOCUMENTS_BUCKET is the bucket S3VectorStore and every other
+            # S3-backed service (files, quiz, research) actually reads/writes.
+            # S3_VECTORS_BUCKET is unused elsewhere and its default name was
+            # never provisioned as a real bucket, so checking it always 404s.
+            if not config.S3_DOCUMENTS_BUCKET:
                 return {
                     "status": "not_configured",
-                    "message": "S3_VECTORS_BUCKET is not set"
+                    "message": "S3_DOCUMENTS_BUCKET is not set"
                 }
 
             from backend.cloud.aws_helpers import get_boto3_client
 
             s3 = get_boto3_client("s3")
-            s3.head_bucket(Bucket=config.S3_VECTORS_BUCKET)
+            s3.head_bucket(Bucket=config.S3_DOCUMENTS_BUCKET)
 
             return {
                 "status": "healthy",
-                "bucket": config.S3_VECTORS_BUCKET,
+                "bucket": config.S3_DOCUMENTS_BUCKET,
                 "message": "Accessible"
             }
 


### PR DESCRIPTION
## Summary
- Fixes the `/health` 503 found during a performance investigation: `HealthChecker.check_s3()` was checking `config.S3_VECTORS_BUCKET`, whose default name (`smart-tutor-{env}-vectors`) was never provisioned as a real S3 bucket and has zero other references in the codebase. The actual production vector store (`s3_vector_store.py`) and every other S3 consumer (files/quiz/research services) all use `config.S3_DOCUMENTS_BUCKET` — a real bucket that's correctly configured and already in active use. The app itself was never broken (`/ready`, which Docker's healthcheck uses, only checks database+redis); only the more comprehensive `/health` endpoint was wrongly reporting `unhealthy`.
- Moves the scheduled RAG evaluation cron from `0 6 * * *` (1am Central, every day including weekends) to `0 16 * * 1-5` (11am CDT / 10am CST, Mon-Fri) so it runs inside the 9AM-5PM Central maintenance window instead of forcing the cost-saving EC2 instance to boot every night outside its intended schedule — same root-cause class as the other production workflows aligned to this window earlier.

## Test plan
- [x] Ran `HealthChecker.check_s3()` locally against real production AWS credentials — confirmed it now returns `{"status": "healthy", "bucket": "smart-ai-tutor-docs", ...}` instead of a 404.
- [x] YAML syntax validated for the workflow change.
- [ ] CI: Backend Tests, SAST/CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the S3 health check to validate the configured documents bucket and report accurate connectivity status.
  * Updated health-check messaging to clearly identify when the documents bucket is not configured.

* **Chores**
  * Scheduled automated evaluations to run weekdays at 16:00 UTC instead of daily at 06:00 UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->